### PR TITLE
Add caffeine module

### DIFF
--- a/bumblebee/modules/caffeine.py
+++ b/bumblebee/modules/caffeine.py
@@ -1,0 +1,40 @@
+import subprocess
+import shlex
+
+import bumblebee.module
+
+def description():
+    return "Enable/disable auto screen lock."
+
+class Module(bumblebee.module.Module):
+    def __init__(self, output, config, alias):
+        super(Module, self).__init__(output, config, alias)
+        self._activated = 0
+        # output.add_callback(module="caffeine.activate", button=1, cmd='notify-send "Consuming caffeine"; xset s off')
+        # output.add_callback(module="caffeine.deactivate", button=1, cmd='notify-send "Out of coffee"; xset s 600 600')
+        output.add_callback(module="caffeine.activate", button=1, cmd='xset s off')
+        output.add_callback(module="caffeine.deactivate", button=1, cmd='xset s 600 600')
+
+    def widgets(self):
+        output = subprocess.check_output(shlex.split("xset q"))
+        xset_out = output.decode().split("\n")
+        for line in xset_out:
+            if line.startswith("  timeout"):
+                timeout = int(line.split(" ")[4])
+                if timeout == 0:
+                    self._activated = 1;
+                else:
+                    self._activated = 0;
+                break
+
+        if self._activated == 0:
+            return bumblebee.output.Widget(self, "", instance="caffeine.activate")
+        elif self._activated == 1:
+            return bumblebee.output.Widget(self, "", instance="caffeine.deactivate")
+
+    def state(self, widget):
+        if self._activated == 1:
+            return "activated"
+        else:
+            return "deactivated"
+

--- a/bumblebee/modules/caffeine.py
+++ b/bumblebee/modules/caffeine.py
@@ -13,7 +13,7 @@ class Module(bumblebee.module.Module):
         # output.add_callback(module="caffeine.activate", button=1, cmd='notify-send "Consuming caffeine"; xset s off')
         # output.add_callback(module="caffeine.deactivate", button=1, cmd='notify-send "Out of coffee"; xset s 600 600')
         output.add_callback(module="caffeine.activate", button=1, cmd='xset s off')
-        output.add_callback(module="caffeine.deactivate", button=1, cmd='xset s 600 600')
+        output.add_callback(module="caffeine.deactivate", button=1, cmd='xset s default')
 
     def widgets(self):
         output = subprocess.check_output(shlex.split("xset q"))

--- a/bumblebee/themes/default.json
+++ b/bumblebee/themes/default.json
@@ -121,5 +121,8 @@
 				"suffix": " dis "
 			}
 		}
+	},
+	"caffeine": {
+		"states": { "activated": {"prefix": "   " }, "deactivated": { "prefix": "   " } }
 	}
 }

--- a/bumblebee/themes/gruvbox-powerline.json
+++ b/bumblebee/themes/gruvbox-powerline.json
@@ -153,5 +153,8 @@
 	},
 	"brightness": {
 		"prefix": "  "
+	},
+	"caffeine": {
+		"states": { "activated": {"prefix": "   " }, "deactivated": { "prefix": "   " } }
 	}
 }

--- a/bumblebee/themes/powerline.json
+++ b/bumblebee/themes/powerline.json
@@ -152,5 +152,8 @@
 				"suffix": "  "
 			}
 		}
+	},
+	"caffeine": {
+		"states": { "activated": {"prefix": "   " }, "deactivated": { "prefix": "   " } }
 	}
 }

--- a/bumblebee/themes/solarized-powerline.json
+++ b/bumblebee/themes/solarized-powerline.json
@@ -153,5 +153,8 @@
 				"suffix": "  "
 			}
 		}
+	},
+	"caffeine": {
+		"states": { "activated": {"prefix": "   " }, "deactivated": { "prefix": "   " } }
 	}
 }

--- a/bumblebee/themes/solarized.json
+++ b/bumblebee/themes/solarized.json
@@ -146,5 +146,8 @@
 				"suffix": " dis "
 			}
 		}
+	},
+	"caffeine": {
+		"states": { "activated": {"prefix": " caf on " }, "deactivated": { "prefix": " caf off " } }
 	}
 }


### PR DESCRIPTION
This module allows you to easily toggle between preventing the screen from turning off and default behaviour. I quite liked the extension available on gnome as it allows you to keep the screen on while watching long youtube videos, so my friend and I ported it to bumblebee, albeit much simpler and with less functionality.

Also, would you mind if I post this project on reddit? I think the folks there would enjoy it.