### PR TITLE
[theme/gruvbox] Remove empty space around the modules

### DIFF
--- a/themes/gruvbox-powerline.json
+++ b/themes/gruvbox-powerline.json
@@ -1,8 +1,6 @@
 {
 	"icons": [ "paxy97", "awesome-fonts" ],
 	"defaults": {
-		"prefix": " ",
-		"suffix" : " ",
 		"warning": {
 			"fg": "#1d2021",
 			"bg": "#d79921"


### PR DESCRIPTION
These margins were driving me crazy so I removed them.