### PR TITLE
Silence ImportErrors for optional dependencies

### DIFF
--- a/bumblebee/modules/cpu.py
+++ b/bumblebee/modules/cpu.py
@@ -7,7 +7,11 @@ Parameters:
     * cpu.critical: Critical threshold in % of CPU usage (defaults to 80%)
 """
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    pass
+
 import bumblebee.input
 import bumblebee.output
 import bumblebee.engine

--- a/bumblebee/modules/memory.py
+++ b/bumblebee/modules/memory.py
@@ -7,7 +7,10 @@ Parameters:
     * cpu.critical: Critical threshold in % of memory used (defaults to 90%)
 """
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    pass
 
 import bumblebee.util
 import bumblebee.input

--- a/bumblebee/modules/nic.py
+++ b/bumblebee/modules/nic.py
@@ -6,7 +6,10 @@ Parameters:
     * nic.exclude: Comma-separated list of interface prefixes to exclude (defaults to "lo,virbr,docker,vboxnet,veth")
 """
 
-import netifaces
+try:
+    import netifaces
+except ImportError:
+    pass
 
 import bumblebee.util
 import bumblebee.input

--- a/bumblebee/modules/weather.py
+++ b/bumblebee/modules/weather.py
@@ -18,7 +18,10 @@ import bumblebee.output
 import bumblebee.engine
 import json
 import time
-import requests
+try:
+    import requests
+except ImportError:
+    pass
 
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):


### PR DESCRIPTION
Quick 'n dirty fix for #55. A better long-term solution might be to declare module aliases outside of modules themselves. Wasn't 100% sure about that, though, and this seemed like the least controversial change.