### PR TITLE
Catch RequestException when fetching weather

### DIFF
--- a/bumblebee/modules/weather.py
+++ b/bumblebee/modules/weather.py
@@ -20,6 +20,7 @@ import json
 import time
 try:
     import requests
+    from requests.exceptions import RequestException
 except ImportError:
     pass
 
@@ -50,17 +51,20 @@ class Module(bumblebee.engine.Module):
     def update(self, widgets):
         timestamp = int(time.time())
         if self._nextcheck < int(time.time()):
-            self._nextcheck = int(time.time()) + self._interval*60
-            weather_url = "http://api.openweathermap.org/data/2.5/weather?appid={}".format(self._apikey)
-            weather_url = "{}&units={}".format(weather_url, self._unit)
-            if self._location == "auto":
-                location_url = "http://ipinfo.io/json"
-                location = json.loads(requests.get(location_url).text)
-                coord = location["loc"].split(",")
-                weather_url = "{url}&lat={lat}&lon={lon}".format(url=weather_url, lat=coord[0], lon=coord[1])
-            else:
-                weather_url = "{url}&q={city}".format(url=weather_url, city=self._location)
-            weather = json.loads(requests.get(weather_url).text)
-            self._temperature = int(weather['main']['temp'])
+            try:
+                self._nextcheck = int(time.time()) + self._interval*60
+                weather_url = "http://api.openweathermap.org/data/2.5/weather?appid={}".format(self._apikey)
+                weather_url = "{}&units={}".format(weather_url, self._unit)
+                if self._location == "auto":
+                    location_url = "http://ipinfo.io/json"
+                    location = json.loads(requests.get(location_url).text)
+                    coord = location["loc"].split(",")
+                    weather_url = "{url}&lat={lat}&lon={lon}".format(url=weather_url, lat=coord[0], lon=coord[1])
+                else:
+                    weather_url = "{url}&q={city}".format(url=weather_url, city=self._location)
+                weather = json.loads(requests.get(weather_url).text)
+                self._temperature = int(weather['main']['temp'])
+            except RequestException:
+                pass
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
## Problem
Whenever internet connection is lost, and _weather_ module is included, the whole status fails. One possible scenario: you wake up your computer from being suspended, and ﻿the whole status fails before the wifi connection could be established.

## Solution
Simply use `try/catch` when retrieving information from web. Therefore, the temperature will not change.

## Follow-up
Even though this fixes the problem, it's not ideal. Say, you don't have connection at the moment of launch, then the temperature will be 0 by default. However, more natural behavior would be to set it to something indicating no information, like `﻿–` or `?`. @tobi-wan-kenobi, how do you feel about this approach?