### PR TITLE
Don't rely on platform specific encoding for Python 3

### DIFF
--- a/bumblebee/theme.py
+++ b/bumblebee/theme.py
@@ -6,7 +6,7 @@ import os
 import glob
 import copy
 import json
-import sys
+import io
 
 import bumblebee.error
 
@@ -110,12 +110,8 @@ class Theme(object):
 
         if os.path.isfile(themefile):
             try:
-                if(sys.version_info > (3,0)):
-                    with open(themefile,encoding="utf-8") as data:
-                        return json.load(data)
-                else:
-                    with open(themefile) as data:
-                        return json.load(data)
+                with io.open(themefile,encoding="utf-8") as data:
+                    return json.load(data)
             except ValueError as exception:
                 raise bumblebee.error.ThemeLoadError("JSON error: {}".format(exception))
         else:

--- a/bumblebee/theme.py
+++ b/bumblebee/theme.py
@@ -109,7 +109,7 @@ class Theme(object):
 
         if os.path.isfile(themefile):
             try:
-                with open(themefile) as data:
+                with open(themefile, encoding="utf-8") as data:
                     return json.load(data)
             except ValueError as exception:
                 raise bumblebee.error.ThemeLoadError("JSON error: {}".format(exception))

--- a/bumblebee/theme.py
+++ b/bumblebee/theme.py
@@ -6,6 +6,7 @@ import os
 import glob
 import copy
 import json
+import sys
 
 import bumblebee.error
 
@@ -109,8 +110,12 @@ class Theme(object):
 
         if os.path.isfile(themefile):
             try:
-                with open(themefile, encoding="utf-8") as data:
-                    return json.load(data)
+                if(sys.version_info > (3,0)):
+                    with open(themefile,encoding="utf-8") as data:
+                        return json.load(data)
+                else:
+                    with open(themefile) as data:
+                        return json.load(data)
             except ValueError as exception:
                 raise bumblebee.error.ThemeLoadError("JSON error: {}".format(exception))
         else:


### PR DESCRIPTION
Hi.

I was getting the following error (using Python 3.6.1):
```
Traceback (most recent call last):
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee/theme.py", line 113, in load
    return json.load(data)
  File "/usr/lib/python3.6/json/__init__.py", line 296, in load
    return loads(fp.read(),
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 29: ordinal not in range(128)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee-status", line 73, in <module>
    main()
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee-status", line 29, in main
    theme = bumblebee.theme.Theme(config.theme())
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee/theme.py", line 27, in __init__
    self._init(self.load(name))
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee/theme.py", line 36, in _init
    self._merge(data, self._load_icons(iconset))
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee/theme.py", line 104, in _load_icons
    return self.load(name, path=path)
  File "/home/thunder/workspace/github/bumblebee-status/bumblebee/theme.py", line 115, in load
    raise bumblebee.error.ThemeLoadError("JSON error: {}".format(exception))
bumblebee.error.ThemeLoadError: JSON error: 'ascii' codec can't decode byte 0xef in position 29: ordinal not in range(128)
[../../i3-4.13/i3bar/src/child.c:339] ERROR: stdin: received EOF
[../../i3-4.13/i3bar/src/child.c:462] ERROR: Child (pid: 6261) unexpectedly exited with status 1
```

Explicitly setting the encoding overcomes this issue since Python 3 decodes text files when reading and the default encoding is platform dependent.

P.S: Props for your work!