### PR TITLE
[modules/spotify] Add rudimentary spotify currently playing module

### DIFF
--- a/bumblebee/modules/spotify.py
+++ b/bumblebee/modules/spotify.py
@@ -1,0 +1,41 @@
+# pylint: disable=C0111,R0903
+
+"""Displays the current song being played
+
+Requires the following library:
+    * python-dbus
+
+Parameters:
+"""
+
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+try:
+    import dbus
+except ImportError:
+    pass
+
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        super(Module, self).__init__(engine, config,
+                                     bumblebee.output.Widget(full_text=self.spotify)
+                                     )
+        self._song = ""
+
+    def spotify(self, widget):
+        return str(self._song)
+
+    def update(self, widgets):
+        try:
+            bus = dbus.SessionBus()
+            spotify = bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
+            spotify_iface = dbus.Interface(spotify, 'org.freedesktop.DBus.Properties')
+            props = spotify_iface.Get('org.mpris.MediaPlayer2.Player', 'Metadata')
+            self._song = (str(props['xesam:artist'][0]) + " - " + str(props['xesam:title']))
+        except dbus.exceptions.DBusException:
+            self._song = "Error: DBus Exception"
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/bumblebee/modules/spotify.py
+++ b/bumblebee/modules/spotify.py
@@ -14,6 +14,7 @@ import bumblebee.engine
 
 try:
     import dbus
+    from dbus.exceptions import DBusException
 except ImportError:
     pass
 
@@ -35,7 +36,7 @@ class Module(bumblebee.engine.Module):
             spotify_iface = dbus.Interface(spotify, 'org.freedesktop.DBus.Properties')
             props = spotify_iface.Get('org.mpris.MediaPlayer2.Player', 'Metadata')
             self._song = (str(props['xesam:artist'][0]) + " - " + str(props['xesam:title']))
-        except dbus.exceptions.DBusException:
-            self._song = "Error: DBus Exception"
+        except DBusException:
+            self._song = ""
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Added a simple Spotify module showing the current playing artist + song.

Just use `spotify` in the modules list.

![2017-05-26-21 15 35](https://cloud.githubusercontent.com/assets/897638/26509313/7e10b9e8-4258-11e7-80cc-d6bb046f4ad8.png)

Thank you @tobi-wan-kenobi for your work!