### PR TITLE
[Output] Only draw widget when full text is not empty

### DIFF
--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -93,6 +93,9 @@ class I3BarOutput(object):
     def draw(self, widget, module=None, engine=None):
         """Draw a single widget"""
         full_text = widget.full_text()
+        """Don't draw it when we only have an empty text"""
+        if full_text == "":
+            return
         padding = self._theme.padding(widget)
         prefix = self._theme.prefix(widget, padding)
         suffix = self._theme.suffix(widget, padding)


### PR DESCRIPTION
Currently an small empty widget is also drawn when the output of the command is empty. This PR changes this behavior.