### PR TITLE
[themes] Added icons for GitHub and Spotify

### DIFF
--- a/themes/icons/ascii.json
+++ b/themes/icons/ascii.json
@@ -77,5 +77,11 @@
 		"shuffle-off": { "prefix": "[s]" },
 		"repeat-on": { "prefix": "R" },
 		"repeat-off": { "prefix": "[r]" }
+	},
+	"github": {
+		"prefix": "github"
+	},
+	"spotify": {
+		"prefix": ""
 	}
 }

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -93,5 +93,11 @@
 		"shuffle-off": { "prefix": "" },
 		"repeat-on": { "prefix": "" },
 		"repeat-off": { "prefix": "" }
-	}
+	},
+  "github": {
+	  "prefix": "  "
+  },
+  "spotify": {
+	  "prefix": "  "
+  }
 }


### PR DESCRIPTION
Added Fontawesome Icon for GitHubs and Spotify.

![2017-05-27-12 48 43](https://cloud.githubusercontent.com/assets/897638/26520845/e0cf292a-42da-11e7-873b-aafd2ffde6d7.png)
