### PR TITLE
[modules/publicip] Add module to show current public IP address

### DIFF
--- a/bumblebee/modules/publicip.py
+++ b/bumblebee/modules/publicip.py
@@ -1,8 +1,5 @@
 """Displays public IP address
 
-Parameter:
-    * Test
-    * Test
 """
 
 try:

--- a/bumblebee/modules/publicip.py
+++ b/bumblebee/modules/publicip.py
@@ -1,0 +1,33 @@
+"""Displays public IP address
+
+Parameter:
+    * Test
+    * Test
+"""
+
+try:
+    from urllib2 import urlopen
+except ImportError:
+    pass
+
+import bumblebee.output
+import bumblebee.engine
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        super(Module, self).__init__(engine, config,
+            bumblebee.output.Widget(full_text=self.public_ip)
+        )
+
+        self._ip = ""
+
+
+    def public_ip(self, widget):
+        return self._ip
+
+    def update(self, widgets):
+        try:
+            self._ip = urlopen("http://ip.42.pl/raw").read()
+        except Exception:
+            self._ip = "Not Connected"
+

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -99,5 +99,8 @@
   },
   "spotify": {
 	  "prefix": "  "
+  },
+  "publicip": {
+	  "prefix": "  "
   }
 }


### PR DESCRIPTION
I added a module that shows your current public IP address. I find it useful when I'm connected to VPNs so I know where I'm reaching the internet from.

It can be added just like any other module by putting `publicip` in the modules list.

P.S. I love using this status bar in i3; thank you so much @tobi-wan-kenobi!