### PR TITLE
[modules/memory] Add parameter to only show used memory

### DIFF
--- a/bumblebee/modules/memory.py
+++ b/bumblebee/modules/memory.py
@@ -3,8 +3,9 @@
 """Displays available RAM, total amount of RAM and percentage available.
 
 Parameters:
-    * cpu.warning : Warning threshold in % of memory used (defaults to 80%)
-    * cpu.critical: Critical threshold in % of memory used (defaults to 90%)
+    * ram.warning : Warning threshold in % of memory used (defaults to 80%)
+    * ram.critical: Critical threshold in % of memory used (defaults to 90%)
+    * ram.usedonly: Only show the amount of RAM in use.
 """
 
 try:
@@ -28,6 +29,8 @@ class Module(bumblebee.engine.Module):
 
     def memory_usage(self, widget):
         used = self._mem.total - self._mem.available
+        if bool(self.parameter("usedonly", 0)) == 1:
+            return bumblebee.util.bytefmt(used)
         return "{}/{} ({:05.02f}%)".format(
             bumblebee.util.bytefmt(used),
             bumblebee.util.bytefmt(self._mem.total),


### PR DESCRIPTION
No change to default behaviour, but adds boolean to only display used rather than used, total and percentage.

To only show used  memory:
-p memory.usedonly=1