### PR TITLE
Disk options

### DIFF
--- a/bumblebee/modules/disk.py
+++ b/bumblebee/modules/disk.py
@@ -6,6 +6,9 @@ Parameters:
     * disk.warning: Warning threshold in % of disk space (defaults to 80%)
     * disk.critical: Critical threshold in % of disk space (defaults ot 90%)
     * disk.path: Path to calculate disk usage from (defaults to /)
+    * disk.showUsed: Show used space (defaults to yes)
+    * disk.showSize: Show total size (defaults to yes)
+    * disk.showPercent: Show usage percentage (defaults to yes)
 """
 
 import os
@@ -20,18 +23,39 @@ class Module(bumblebee.engine.Module):
             bumblebee.output.Widget(full_text=self.diskspace)
         )
         self._path = self.parameter("path", "/")
+        self._sused = self.parameter("showUsed", "yes")
+        self._ssize = self.parameter("showSize", "yes")
+        self._spercent = self.parameter("showPercent", "yes")
         self._perc = 0
         self._used = 0
         self._size = 0
 
         engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE,
-            cmd="nautilus {}".format(self._path))
+                                       cmd="nautilus {}".format(self._path))
 
     def diskspace(self, widget):
-        return "{} {}/{} ({:05.02f}%)".format(self._path,
-            bumblebee.util.bytefmt(self._used),
-            bumblebee.util.bytefmt(self._size), self._perc
-        )
+        if self._sused == "yes":
+            used_str = bumblebee.util.bytefmt(self._used)
+        else:
+            used_str = ""
+        if self._ssize == "yes":
+            size_str = bumblebee.util.bytefmt(self._size)
+        else:
+            size_str = ""
+        if self._spercent == "yes":
+            percent_str = self._perc
+        else:
+            percent_str = ""
+        if self._sused != "yes" or self._ssize != "yes":
+            separator = ""
+        else:
+            separator = "/"
+
+        return "{} {}{}{} ({:05.02f}%)".format(self._path,
+                                               used_str,
+                                               separator,
+                                               size_str,
+                                               percent_str)
 
     def update(self, widgets):
         st = os.statvfs(self._path)

--- a/bumblebee/modules/disk.py
+++ b/bumblebee/modules/disk.py
@@ -6,6 +6,7 @@ Parameters:
     * disk.warning: Warning threshold in % of disk space (defaults to 80%)
     * disk.critical: Critical threshold in % of disk space (defaults ot 90%)
     * disk.path: Path to calculate disk usage from (defaults to /)
+    * disk.open: Which application / file manager to launch (default xdg-open)
     * disk.showUsed: Show used space (defaults to yes)
     * disk.showSize: Show total size (defaults to yes)
     * disk.showPercent: Show usage percentage (defaults to yes)
@@ -26,12 +27,14 @@ class Module(bumblebee.engine.Module):
         self._sused = self.parameter("showUsed", "yes")
         self._ssize = self.parameter("showSize", "yes")
         self._spercent = self.parameter("showPercent", "yes")
+        self._app = self.parameter("open", "xdg-open")
         self._perc = 0
         self._used = 0
         self._size = 0
 
         engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE,
-                                       cmd="nautilus {}".format(self._path))
+                                       cmd="{} {}".format(self._app,
+                                                          self._path))
 
     def diskspace(self, widget):
         if self._sused == "yes":


### PR DESCRIPTION
Added a few more options to the disk module. This is mainly because I found it annoying that it was spitting a lot of text and my bar wouldn't fit the screen so I've put in some options to control what information is shown. Also, I added an option to select which application / file manager to launch upon mouse click. Note that I defaulted the value to "xdg-open", which will automagically open the default file manager (I think this is more general, and also, I myself don't have nautilus installed for instance.)