### PR TITLE
[module/cpu] More useful rounding

### DIFF
--- a/bumblebee/modules/cpu.py
+++ b/bumblebee/modules/cpu.py
@@ -26,7 +26,7 @@ class Module(bumblebee.engine.Module):
             cmd="gnome-system-monitor")
 
     def utilization(self, widget):
-        return "{:06.02f}%".format(self._utilization)
+        return "{:6.01f}%".format(self._utilization)
 
     def update(self, widgets):
         self._utilization = psutil.cpu_percent(percpu=False)


### PR DESCRIPTION
psutil.cpu_percent() only outputs to one decimal place anyway, so the trailing 0 is useless.
The prepended 0 is also not important, will only be not 0 at 100% utilization, so why not let it be 100% then and take up one less column otherwise?