### PR TITLE
[themes/icons/awesome-fonts] Replace "Sensors" icon FA alt

### DIFF
--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -82,7 +82,7 @@
 		"day": { "prefix": "" }, "night": { "prefix": "" }, "transition": { "prefix": "" }
 	},
   "sensors": {
-    "prefix": "🌡"
+    "prefix": ""
   },
   "traffic":{
 	  "rx": { "prefix": "" },


### PR DESCRIPTION
The current thermometer icon isn't actually included in fontawesome, requiring a user to install and find another font that does support it, such as symbola or nota-emoji
Since this is for font-awesome it would make sense to only require font-awesome.