### PR TITLE
[modules/github] Use header rather than url for token

### DIFF
--- a/bumblebee/modules/github.py
+++ b/bumblebee/modules/github.py
@@ -44,7 +44,7 @@ class Module(bumblebee.engine.Module):
                  self._count = 0
                  return
 
-            notifications = requests.get("https://api.github.com/notifications?access_token={}".format(token)).text
+            notifications = requests.get("https://api.github.com/notifications", headers={"Authorization":"token "+format(token)}).text
             unread = 0
             for notification in json.loads(notifications):
                 if "unread" in notification and notification["unread"] == True:


### PR DESCRIPTION
Doesnt allow sniffers to get the access token from url.
Closes #104