### PR TITLE
Added a new module to show your current todo items

### DIFF
--- a/bumblebee/modules/todo.py
+++ b/bumblebee/modules/todo.py
@@ -33,7 +33,7 @@ class Module(bumblebee.engine.Module):
     def count_items(filename):
         try:
             i=-1
-            with open('/home/codingo/Documents/todo.txt') as f:
+            with open('~/Documents/todo.txt') as f:
                 for i, l in enumerate(f):
                     pass
             return i+1 

--- a/bumblebee/modules/todo.py
+++ b/bumblebee/modules/todo.py
@@ -1,0 +1,43 @@
+# pylint: disable=C0111,R0903
+
+"""Displays the number of todo items in ~/Documents/todo.txt"""
+
+import platform
+
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+
+class Module(bumblebee.engine.Module):
+
+    
+    def __init__(self, engine, config):
+        super(Module, self).__init__(engine, config,
+            bumblebee.output.Widget(full_text=self.output)
+        )
+        self._todos = self.count_items() 
+
+
+    def output(self, widget):
+       self._todos = self.count_items()
+       return self._todos 
+
+    
+    def state(self, widgets):
+        if self._todos == 0 :
+            return "empty"
+        return "items"
+        
+
+    def count_items(filename):
+        try:
+            i=-1
+            with open('/home/codingo/Documents/todo.txt') as f:
+                for i, l in enumerate(f):
+                    pass
+            return i+1 
+        except Exception:
+            return 0
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -14,6 +14,10 @@
 	"brightness": { "prefix": "" },
 	"load": { "prefix": "" },
 	"layout": { "prefix": "" },
++       "todo": { "empty": {"prefix": "" },
+	+         "items": {"prefix": "" }
+	},
+
 	"cmus": {
 		"playing": { "prefix": "" },
 		"paused": { "prefix": "" },


### PR DESCRIPTION
A large number of linux administrators use a variety of todo applications that write a file "todo.txt" to their home folder. This plugin counts the number of items in this list (by line count) and displays it in the i3 bar.