### PR TITLE
Remove xbacklight dependency from brightness module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Modules and commandline utilities are only required for modules, the core itself
 
 # Required commandline utilities
 
-* xbacklight (for the module 'brightness')
 * xset (for the module 'caffeine')
 * notify-send (for the module 'caffeine')
 * cmus-remote (for the module 'cmus')


### PR DESCRIPTION
Modified brightness module to work under [sway](https://github.com/SirCmpwn/sway)/wayland by removing xbacklight dependency. Changes made were more for personal use but hopefully, someone else might find this useful.