### PR TITLE
github module: move the requests.get inside the try/except

### DIFF
--- a/bumblebee/modules/github.py
+++ b/bumblebee/modules/github.py
@@ -39,12 +39,12 @@ class Module(bumblebee.engine.Module):
             token = self.parameter("token", "")
 
             if not token:
-                self._count = 0
+                self._count = "n/a"
                 return
               
-            notifications = requests.get("https://api.github.com/notifications", headers={"Authorization":"token {}".format(token)}).text
-            unread = 0
             try:
+                notifications = requests.get("https://api.github.com/notifications", headers={"Authorization":"token {}".format(token)}).text
+                unread = 0
                 for notification in json.loads(notifications):
                     if "unread" in notification and notification["unread"]:
                         unread += 1


### PR DESCRIPTION
otherwise the bar is terminated on network error, also set the output to 'n/a' instead of '0' if the GitHub token is not present