### PR TITLE
Add click events to Spotify module

### DIFF
--- a/bumblebee/modules/spotify.py
+++ b/bumblebee/modules/spotify.py
@@ -25,6 +25,15 @@ class Module(bumblebee.engine.Module):
                                      )
         self._song = ""
 
+        cmd="dbus-send --session --type=method_call --dest=org.mpris.MediaPlayer2.spotify \
+                /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player."
+        engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE,
+            cmd=cmd + "Previous")
+        engine.input.register_callback(self, button=bumblebee.input.RIGHT_MOUSE,
+            cmd=cmd + "Next")
+        engine.input.register_callback(self, button=bumblebee.input.MIDDLE_MOUSE,
+            cmd=cmd + "PlayPause")
+
     def spotify(self, widget):
         return str(self._song)
 


### PR DESCRIPTION
Added support for click events on Spotify.

Left click: previous song
Right click: next song
Middle click: play/pause.

It uses dbus-send so no additional dependencies AFAIK.

Thanks @tobi-wan-kenobi for the great project.