### PR TITLE
Locale for datetime module

### DIFF
--- a/bumblebee/modules/datetime.py
+++ b/bumblebee/modules/datetime.py
@@ -10,7 +10,10 @@ Parameters:
 
 from __future__ import absolute_import
 import datetime
+import locale
 import bumblebee.engine
+
+locale.setlocale(locale.LC_TIME, locale.getdefaultlocale())
 
 ALIASES = [ "date", "time" ]
 


### PR DESCRIPTION
Allows usage of strings like %x, %X for the datetime format.