### PR TITLE
CPU icon and datetime locale

### DIFF
--- a/bumblebee/modules/datetime.py
+++ b/bumblebee/modules/datetime.py
@@ -31,12 +31,14 @@ class Module(bumblebee.engine.Module):
         super(Module, self).__init__(engine, config,
             bumblebee.output.Widget(full_text=self.get_time))
         self._fmt = self.parameter("format", default_format(self.name))
-        self._lcl = self.parameter("locale").split(".")
+        lcl = self.parameter("locale")
 
         # can't use the default in "parameter" because we split the
         # string, while 'getdefaultlocale' already returns a tuple
-        if self._lcl is None:
+        if lcl is None:
             self._lcl = locale.getdefaultlocale()
+        else:
+            self._lcl = lcl.split(".")
         locale.setlocale(locale.LC_TIME, self._lcl)
 
     def get_time(self, widget):

--- a/bumblebee/modules/datetime.py
+++ b/bumblebee/modules/datetime.py
@@ -6,14 +6,15 @@ Parameters:
     * datetime.format: strftime()-compatible formatting string
     * date.format    : alias for datetime.format
     * time.format    : alias for datetime.format
+    * datetime.locale: locale to use rather than the system default
+    * date.locale    : alias for datetime.locale
+    * time.locale    : alias for datetime.locale
 """
 
 from __future__ import absolute_import
 import datetime
 import locale
 import bumblebee.engine
-
-locale.setlocale(locale.LC_TIME, locale.getdefaultlocale())
 
 ALIASES = [ "date", "time" ]
 
@@ -28,9 +29,15 @@ def default_format(module):
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
         super(Module, self).__init__(engine, config,
-            bumblebee.output.Widget(full_text=self.get_time)
-        )
+            bumblebee.output.Widget(full_text=self.get_time))
         self._fmt = self.parameter("format", default_format(self.name))
+        self._lcl = self.parameter("locale").split(".")
+
+        # can't use the default in "parameter" because we split the
+        # string, while 'getdefaultlocale' already returns a tuple
+        if self._lcl is None:
+            self._lcl = locale.getdefaultlocale()
+        locale.setlocale(locale.LC_TIME, self._lcl)
 
     def get_time(self, widget):
         return datetime.datetime.now().strftime(self._fmt)

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -7,7 +7,7 @@
 	"time": { "prefix": "" },
 	"datetime": { "prefix": "" },
 	"memory": { "prefix": "" },
-	"cpu": { "prefix": "" },
+	"cpu": { "prefix": "" },
 	"disk": { "prefix": "" },
 	"dnf": { "prefix": "" },
 	"pacman": { "prefix": "" },


### PR DESCRIPTION
I'm not sure why the CPU icon was changed in df6e323 but it stopped working for me. This PR reverts that and also adds functionality to override the locale in datetime.