### PR TITLE
Added parameter showname to hide network interface

### DIFF
--- a/bumblebee/modules/traffic.py
+++ b/bumblebee/modules/traffic.py
@@ -5,6 +5,7 @@
 Parameters:
     * traffic.exclude: Comma-separated list of interface prefixes to exclude (defaults to "lo,virbr,docker,vboxnet,veth")
     * traffic.states: Comma-separated list of states to show (prefix with "^" to invert - i.e. ^down -> show all devices that are not in state down)
+    * traffic.showname: set as False to hide network interface name 
 """
 
 import re
@@ -23,6 +24,7 @@ class Module(bumblebee.engine.Module):
         self._exclude = tuple(filter(len, self.parameter("exclude", "lo,virbr,docker,vboxnet,veth").split(",")))
         self._status = ""
 
+        self._showname = self.parameter("showname", "True") 
         self._prev = {}
         self._states = {}
         self._states["include"] = []
@@ -85,8 +87,9 @@ class Module(bumblebee.engine.Module):
             }
 
             name = "traffic-{}".format(interface)
-
-            self.create_widget(widgets, name, interface)
+            
+            if self._showname != "False":
+               self.create_widget(widgets, name, interface)
 
             for direction in ["rx", "tx"]:
                 name = "traffic.{}-{}".format(direction, interface)


### PR DESCRIPTION
Becomes a needless info for personal laptop usages where only one interface is used.