### PR TITLE
BUG: github module count breaks in python3

### DIFF
--- a/bumblebee/modules/github.py
+++ b/bumblebee/modules/github.py
@@ -49,7 +49,7 @@ class Module(bumblebee.engine.Module):
                 url = "https://api.github.com/notifications"
                 while True:
                     notifications = self._requests.get(url)
-                    self._count += len(filter(lambda notification: notification.get("unread", False), notifications.json()))
+                    self._count += len(list(filter(lambda notification: notification['unread'], notifications.json())))
                     next_link = notifications.links.get('next')
                     if next_link is not None:
                         url = next_link.get('url')


### PR DESCRIPTION
In python2, `filter()` returned a list, but in python3 it returns an iterator. So
we wrap this in a `list()` so that it works in both.  We also want to count the
unread notifications, so this should be reflected in the code.