### PR TITLE
modules/sensors: Try intel scaling current frequency

### DIFF
--- a/bumblebee/modules/sensors.py
+++ b/bumblebee/modules/sensors.py
@@ -47,9 +47,13 @@ class Module(bumblebee.engine.Module):
         return temperature
 
     def get_mhz( self ):
-        output = open("/proc/cpuinfo").read()
-        m      = re.search(r"cpu MHz\s+:\s+(\d+)", output)
-        mhz    = int(m.group(1))
+        try:
+            output = open("/sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq").read()
+            mhz = int(float(output)/1000.0)
+        except:
+            output = open("/proc/cpuinfo").read()
+            m      = re.search(r"cpu MHz\s+:\s+(\d+)", output)
+            mhz    = int(m.group(1))
 
         if mhz < 1000:
             return "{} MHz".format(mhz)


### PR DESCRIPTION
On intel pstate drivers only the normal frequency is written to /proc/cpuinfo, not accounting for scaling/turbo.
This should fix that, though it needs testing on other computers (AMD, intel without pstate) because I am not
certain that the file only exists on Intel pstate.