### PR TITLE
nvidiagpu.py: remove invalid shebang

### DIFF
--- a/bumblebee/modules/nvidiagpu.py
+++ b/bumblebee/modules/nvidiagpu.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """Displays GPU name, temperature and memory usage.


### PR DESCRIPTION
This file has no actionable code when executed directly from a shell. It contains only a `class` as it is a bumblebee module.

so the shebang should be removed.