### PR TITLE
[modules/rotation] new module to loop through orientations

### DIFF
--- a/bumblebee/modules/rotation.py
+++ b/bumblebee/modules/rotation.py
@@ -1,0 +1,70 @@
+# pylint: disable=C0111,R0903
+
+"""Shows a widget for each connected screen and allows the user to loop through different orientations.
+
+Requires the following executable:
+    * xrandr
+"""
+
+import os
+import re
+import sys
+
+import bumblebee.util
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+possible_orientations = ["normal", "left", "inverted", "right"]
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        widgets = []
+        self._engine = engine
+        super(Module, self).__init__(engine, config, widgets)
+        self.update_widgets(widgets)
+
+    def update_widgets(self, widgets):
+        new_widgets = []
+        for line in bumblebee.util.execute("xrandr -q").split("\n"):
+            if not " connected" in line:
+                continue
+            display = line.split(" ", 2)[0]
+
+            orientation = "normal"
+            for curr_orient in possible_orientations:
+                if((line.split(" ")).count(curr_orient) > 1):
+                    orientation = curr_orient
+                    break
+
+            widget = self.widget(display)
+            if not widget:
+                widget = bumblebee.output.Widget(full_text=display, name=display)
+                self._engine.input.register_callback(widget, button=bumblebee.input.LEFT_MOUSE, cmd=self._toggle)
+            new_widgets.append(widget)
+            widget.set("orientation", orientation)
+
+        while len(widgets) > 0:
+            del widgets[0]
+        for widget in new_widgets:
+            widgets.append(widget)
+
+    def update(self, widgets):
+        self.update_widgets(widgets)
+
+    def state(self, widget):
+        return widget.get("orientation", "normal")
+
+    def _toggle(self, event):
+        widget = self.widget_by_id(event["instance"])
+
+        # compute new orientation based on current orientation
+        idx = possible_orientations.index(widget.get("orientation"))
+        idx = (idx + 1) % len(possible_orientations)
+        new_orientation = possible_orientations[idx]
+
+        widget.set("orientation", new_orientation)
+
+        bumblebee.util.execute("xrandr --output {} --rotation {}".format(widget.name, new_orientation))
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
New module to change the orientation of a specific display. 
* Instead of having a static default orientation to change to when the widget is toggled, this module cycles through all possible orientations.
* loosely based on the `xrandr` module. 