### PR TITLE
[modules/mpd] Fixed song duration parse bug

### DIFF
--- a/bumblebee/modules/mpd.py
+++ b/bumblebee/modules/mpd.py
@@ -86,10 +86,7 @@ class Module(bumblebee.engine.Module):
                 self._status = "paused"
 
             if line.startswith("["):
-                if len(line.split("   ")) > 1:
-                    timer = line.split("   ")[1]
-                else:
-                    timer = line.split("  ")[1]
+                timer = line.split()[2]
                 position = timer.split("/")[0]
                 dur = timer.split("/")[1]
                 duration = dur.split(" ")[0]

--- a/bumblebee/modules/mpd.py
+++ b/bumblebee/modules/mpd.py
@@ -86,7 +86,10 @@ class Module(bumblebee.engine.Module):
                 self._status = "paused"
 
             if line.startswith("["):
-                timer = line.split("   ")[1]
+                if len(line.split("   ")) > 1:
+                    timer = line.split("   ")[1]
+                else:
+                    timer = line.split("  ")[1]
                 position = timer.split("/")[0]
                 dur = timer.split("/")[1]
                 duration = dur.split(" ")[0]


### PR DESCRIPTION
After listening to an audio stream for longer than 10 minutes `mpc -f "tag artist %artist%\ntag title %title%"` will start producing lines with slightly different separation.
Before 10 minutes:
```
$ mpc -f "tag artist %artist%\ntag title %title%"
tag artist 
tag title Camembert Electrique - Gong - You Can't Kill Me
[playing] #173/173   9:29/0:00 (0%)
volume:100%   repeat: off   random: off   single: off   consume: off
```
After 10 minutes:
```
$ mpc -f "tag artist %artist%\ntag title %title%"
tag artist 
tag title Camembert Electrique - Gong - You Can't Kill Me
[playing] #173/173  10:02/0:00 (0%)
volume:100%   repeat: off   random: off   single: off   consume: off
```
The `[playing]` line has one less space, which meant that `line.split("    ")` wouldn't split the line properly. As far as I know, this only happens on URL audio streams like `http://stream-dc1.radioparadise.com/aac-320`. 