### PR TITLE
[modules/brightness] Fix return format

### DIFF
--- a/bumblebee/modules/brightness.py
+++ b/bumblebee/modules/brightness.py
@@ -29,7 +29,7 @@ class Module(bumblebee.engine.Module):
 
     def brightness(self, widget):
         if isinstance(self._brightness, float):
-            return "{:03.0f}%".format(self._brightness)
+            return "{:3.0f}%".format(self._brightness).strip()
         else:
             return "n/a"
 


### PR DESCRIPTION
Hi.

I've noticed this a while ago and decided to send a pull request. It's a minor issue that bothered me a little bit. It worked in my environment, so I think it's okay.

**What:** Fixes the return format in `brightness` module.
**Why:** To remove the initial zero in the brightness indicator when below hundred.

**Before:**

![ss__01-31__06-41-06__309x54](https://user-images.githubusercontent.com/12755789/35647877-1f36340c-06bb-11e8-9510-bcaa8c5a9bef.png)
![ss__01-31__06-42-10__309x55](https://user-images.githubusercontent.com/12755789/35647885-27454a8e-06bb-11e8-861c-b86d01868ab4.png)

**After:**

![ss__01-31__07-16-50__306x49](https://user-images.githubusercontent.com/12755789/35647956-5ab73184-06bb-11e8-9ea2-389abbcb1730.png)
![ss__01-31__07-17-00__313x52](https://user-images.githubusercontent.com/12755789/35647961-5e58147a-06bb-11e8-90e8-e9af0cb3a262.png)

Thank you for all the effort put in this project!

