### PR TITLE
[modules/traffic] Add parameter to hide down networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Here are some screenshots for all themes that currently exist:
 
 :exclamation: Some themes (all 'Powerline' themes) require [Font Awesome](http://fontawesome.io/) and a powerline-compatible font ([powerline-fonts](https://github.com/powerline/fonts), for example) to display all icons correctly.
 
-Gruvbox Powerline (`-t gruvbox-powerline`) (contributed by [@paxy97](https://github.com/paxy97)):
+Gruvbox Powerline (`-t gruvbox-powerline`) (contributed by [@TheEdgeOfRage](https://github.com/TheEdgeOfRage)):
 
 ![Gruvbox Powerline](https://github.com/tobi-wan-kenobi/bumblebee-status/blob/master/screenshots/themes/powerline-gruvbox.png)
 

--- a/bumblebee/modules/traffic.py
+++ b/bumblebee/modules/traffic.py
@@ -76,6 +76,8 @@ class Module(bumblebee.engine.Module):
             state = "down"
             if len(self.get_addresses(interface)) > 0:
                 state = "up"
+            elif bumblebee.util.asbool(self.parameter("hide_down", True)):
+                continue
 
             if len(self._states["exclude"]) > 0 and state in self._states["exclude"]: continue
             if len(self._states["include"]) > 0 and state not in self._states["include"]: continue


### PR DESCRIPTION
Add a optional parameter to the traffic module to hide networks that are inactive (have no id address). It became frustrating to have it take up a whole screen width of space when I have three interfaces with only one active.