### PR TITLE
publicip: use checkip.amazonaws.com in us-east

### DIFF
--- a/bumblebee/modules/publicip.py
+++ b/bumblebee/modules/publicip.py
@@ -21,7 +21,7 @@ class Module(bumblebee.engine.Module):
         super(Module, self).__init__(engine, config,
             bumblebee.output.Widget(full_text=self.public_ip)
         )
-        self._avail_regions = {"us-east":"http://l2.io/ip",
+        self._avail_regions = {"us-east":"http://checkip.amazonaws.com",
                                "us-central":"http://whatismyip.akamai.com",
                                "us-west":"http://ipv4bot.whatismyipaddress.com",
                                "pl":"http://ip.42.pl/raw",


### PR DESCRIPTION
I'm on the east coast, and on average the amazon endpoint is a bit faster. AWS is also a more well known name.