### PR TITLE
Reverse the words in theme name for correctness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Powerline (`-t powerline`):
 
 ![Powerline](https://github.com/tobi-wan-kenobi/bumblebee-status/blob/master/screenshots/themes/powerline.png)
 
-Greyish Powerline (`-t powerline-greyish`)
+Greyish Powerline (`-t greyish-powerline`)
 
 ![Greyish Powerline](https://github.com/tobi-wan-kenobi/bumblebee-status/blob/master/screenshots/themes/powerline-greyish.png)
 


### PR DESCRIPTION
The words around the dash were in the wrong order.