### PR TITLE
Adding gruvbox "light" theme

### DIFF
--- a/themes/gruvbox-light.json
+++ b/themes/gruvbox-light.json
@@ -1,0 +1,47 @@
+{
+	"icons": [ "paxy97", "ascii" ],
+	"defaults": {
+		"warning": {
+			"fg": "#1d2021",
+			"bg": "#d79921"
+		},
+		"critical": {
+			"fg": "#fbf1c7",
+			"bg": "#cc241d"
+		},
+		"default-separators": false,
+		"separator-block-width": 0
+	},
+	"cycle": [
+		{
+			"fg": "#1d2021",
+			"bg": "#ebdbb2"
+		},
+		{
+			"fg": "#282828",
+			"bg": "#fbf1c7"
+		}
+	],
+	"dnf": {
+		"good": {
+			"fg": "#002b36",
+			"bg": "#859900"
+		}
+	},
+	"battery": {
+		"charged": {
+			"fg": "#1d2021",
+			"bg": "#b8bb26"
+		},
+		"AC": {
+			"fg": "#1d2021",
+			"bg": "#b8bb26"
+		}
+  },
+  "bluetooth": {
+      "ON": {
+			    "fg": "#1d2021",
+			    "bg": "#b8bb26"
+      }
+	}
+}

--- a/themes/gruvbox-powerline-light.json
+++ b/themes/gruvbox-powerline-light.json
@@ -1,0 +1,47 @@
+{
+	"icons": [ "paxy97", "awesome-fonts" ],
+	"defaults": {
+		"warning": {
+			"fg": "#1d2021",
+			"bg": "#d79921"
+		},
+		"critical": {
+			"fg": "#fbf1c7",
+			"bg": "#cc241d"
+		},
+		"default-separators": false,
+		"separator-block-width": 0
+	},
+	"cycle": [
+		{
+			"fg": "#1d2021",
+			"bg": "#ebdbb2"
+		},
+		{
+			"fg": "#282828",
+			"bg": "#fbf1c7"
+		}
+	],
+	"dnf": {
+		"good": {
+			"fg": "#002b36",
+			"bg": "#859900"
+		}
+	},
+	"battery": {
+		"charged": {
+			"fg": "#1d2021",
+			"bg": "#b8bb26"
+		},
+		"AC": {
+			"fg": "#1d2021",
+			"bg": "#b8bb26"
+		}
+	},
+  "bluetooth": {
+      "ON": {
+			    "fg": "#1d2021",
+			    "bg": "#b8bb26"
+      }
+  }
+}


### PR DESCRIPTION
Hi,

I would like to have a light version of the gruvbox theme, I just switched the foreground and background colors in the cycle.

You can see here how it looks. 

![2018-05-07-013009_1920x1080_scrot](https://user-images.githubusercontent.com/9461698/39678915-3d832c78-5196-11e8-969e-f179e0fb04d1.png)
