### PR TITLE
Fixed issue where pulseaudio module could monitor the wrong device if…

### DIFF
--- a/bumblebee/modules/pulseaudio.py
+++ b/bumblebee/modules/pulseaudio.py
@@ -102,7 +102,7 @@ class Module(bumblebee.engine.Module):
             found = False
 
             for line in result.split("\n"):
-                if device in line:
+                if "<"+device+">" in line:
                     found = True
                     continue
                 if found == False:


### PR DESCRIPTION
… certain pa modules have been loaded (e.g. monitoring 'alsa_output.pci-0000_00_1b.0.analog-stereo.echo-cancel' rather than 'alsa_output.pci-0000_00_1b.0.analog-stereo'