### PR TITLE
[module] - adding caps/num/scrl indicator widget; pacman to sum the digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Visual studio project files
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test Coverage](https://codeclimate.com/github/tobi-wan-kenobi/bumblebee-status/badges/coverage.svg)](https://codeclimate.com/github/tobi-wan-kenobi/bumblebee-status/coverage)
 [![Issue Count](https://codeclimate.com/github/tobi-wan-kenobi/bumblebee-status/badges/issue_count.svg)](https://codeclimate.com/github/tobi-wan-kenobi/bumblebee-status)
 
-**Many, many thanks to all contributors! As of now, 26 of the modules are from various contributors (!), and only 16 from myself.**
+**Many, many thanks to all contributors! As of now, 27 of the modules are from various contributors (!), and only 16 from myself.**
 
 ![Solarized Powerline](https://github.com/tobi-wan-kenobi/bumblebee-status/blob/master/screenshots/themes/powerline-solarized.png)
 

--- a/bumblebee/modules/indicator.py
+++ b/bumblebee/modules/indicator.py
@@ -1,0 +1,51 @@
+#pylint: disable=C0111,R0903
+
+"""Displays the indicator status, for numlock, scrolllock and capslock 
+
+Parameters:
+    * indicator.include: Comma-separated list of interface prefixes to include (defaults to "numlock,capslock")
+    * indicator.signalstype: If you want the signali type color to be "critical" or "warning" (defaults to "warning")
+"""
+
+
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        widgets = []
+        self.status = False
+        super(Module,self).__init__(engine, config, widgets)
+        self._include = tuple(filter(len, self.parameter("include", "NumLock,CapsLock").split(",")))
+        self._signalType = self.parameter("signaltype") if not self.parameter("signaltype") == None else "warning"
+
+    def update(self, widgets):
+        self._update_widgets(widgets)
+
+    def state(self, widget):
+        states = []
+        if widget.status:
+            states.append(self._signalType)
+        elif not widget.status:
+            states.append("normal")
+        return states
+
+    def _update_widgets(self, widgets):
+        status_line = "" 
+        for line in bumblebee.util.execute("xset q").replace(" ", "").split("\n"):
+            if "capslock" in line.lower():
+                status_line = line  
+                break
+            
+        for indicator in self._include:
+            widget = self.widget(indicator)
+            if not widget:
+                widget = bumblebee.output.Widget(name=indicator)
+                widgets.append(widget)
+
+            widget.status = True if indicator.lower()+":on" in status_line.lower() else False
+            widget.full_text(indicator)
+
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/bumblebee/modules/pacman.py
+++ b/bumblebee/modules/pacman.py
@@ -1,6 +1,9 @@
 # pylint: disable=C0111,R0903
 
-"""Displays update information per repository for pacman."
+"""Displays update information per repository for pacman.
+
+Parameters:
+    * pacman.sum: If you prefere displaying updates with a single digit (defaults to "False")
 
 Requires the following executables:
     * fakeroot
@@ -45,8 +48,12 @@ class Module(bumblebee.engine.Module):
             bumblebee.output.Widget(full_text=self.updates)
         )
         self._count = 0
+        self._sum = True if self.parameter("sum") == "True" else False 
+
 
     def updates(self, widget):
+        if (self._sum):
+            return str(sum(map(lambda x: widget.get(x, 0), repos)))
         return '/'.join(map(lambda x: str(widget.get(x, 0)), repos))
 
     def update(self, widgets):


### PR DESCRIPTION
Hi,

My problem is that on my keyboard there are no LEDs that would signal me if Numlock or Caplock are enabled leading me sometimes in a full Rage cause vim stars to jump around.

It uses the "xset q" command like does the caffeine widget.

Some modularity is there too, like changing the color of indicating or any caps "Numlock = nUmLoCk".
![2018-05-12-194435_1920x1080_scrot](https://user-images.githubusercontent.com/9461698/39960106-ede44dd8-561c-11e8-9dad-d05d6485f18c.png)
