### PR TITLE
[module/amixer] Add on/off mute check

### DIFF
--- a/bumblebee/modules/amixer.py
+++ b/bumblebee/modules/amixer.py
@@ -21,7 +21,7 @@ class Module(bumblebee.engine.Module):
         m = re.search(r'([\d]+)\%', self._level)
         self._muted = True
         if m:
-            if m.group(1) != "0":
+            if m.group(1) != "0" and "[on]" in self._level:
                 self._muted = False
             return "{}%".format(m.group(1))
         else:


### PR DESCRIPTION
Hi,

When the volume is >0%, but the channel is muted, the amixer module doesn't detect this and still shows Master as unmuted on the statusbar. Example: `Mono: Playback 56 [44%] [-53.25dB] [off]`

Is this intentional? If not, do you think we could add a check for this?

