### PR TITLE
Respect autostart parameter.

### DIFF
--- a/bumblebee/modules/pulseaudio.py
+++ b/bumblebee/modules/pulseaudio.py
@@ -29,7 +29,8 @@ class Module(bumblebee.engine.Module):
             bumblebee.output.Widget(full_text=self.volume)
         )
         try:
-            bumblebee.util.execute("pulseaudio --start")
+            if bumblebee.util.asbool(self.parameter("autostart", False)):
+                bumblebee.util.execute("pulseaudio --start")
         except Exception:
             pass
 


### PR DESCRIPTION
So, a while ago my pulseaudio stopped working (trying to connect with pavucontrol or anything it hangs and says it can't connect). I only just got around to trying to figure out what it was.

So it seems it's due to bumblebee and this specific line in the pulseaudio module. I noticed the auto-start variable so I made sure that this line is only executed if the variable is set.

So I don't _really_ know pulseaudio, but my system (arch) has pulseaudio started by default when it's needed. I wonder if this `pulseaudio --start` messes with that process somehow ([ref](https://wiki.archlinux.org/index.php/PulseAudio#Running)).

Either way, my system is broken without this line.