### PR TITLE
Left mouse click on datetime module opens gsimplecal

### DIFF
--- a/bumblebee/modules/datetime.py
+++ b/bumblebee/modules/datetime.py
@@ -37,6 +37,8 @@ class Module(bumblebee.engine.Module):
         lcl = self.parameter("locale", ".".join(l))
         locale.setlocale(locale.LC_TIME, lcl.split("."))
 
+        engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE, cmd="gsimplecal")
+
     def get_time(self, widget):
         enc = locale.getpreferredencoding()
         retval = datetime.datetime.now().strftime(self._fmt)


### PR DESCRIPTION
This PR adds support for displaying a mini calendar when left clicking the datetime module.

I simply registered a callback to run [`gsimplecal`](https://github.com/dmedvinsky/gsimplecal).

In my i3 config file I have

```
for_window [class="(?i)gsimplecal"] floating enable, move position mouse, move up $height px
```

where `$height` is the height of my status bar.

The result is the following:

![selection_020](https://user-images.githubusercontent.com/6341745/44202620-cafd8980-a14c-11e8-9000-0ea1c30a76da.png)

`gsimplecal` is very configurable and can show clocks for multiple timezones and close automatically when the window is unfocused.

Regarding the added code in this PR, I'm not sure whether we should register the callback unconditionally since I don't think we should make `gsimplecal` a hard requirement for a module as popular as datetime. However, I also don't see any drawback because if the user does not have `gsimplecal` installed, a left click on the datetime module will simply not do anything.

If everything looks good though, I'll go ahead and update the docs.
