### PR TITLE
Add iceberg-powerline theme

### DIFF
--- a/themes/iceberg-powerline.json
+++ b/themes/iceberg-powerline.json
@@ -1,0 +1,44 @@
+{
+    "icons": [ "awesome-fonts" ],
+    "defaults": {
+        "separator-block-width": 0,
+        "warning": {
+            "fg": "#e2a478",
+            "bg": "#c6c8d1"
+        },
+        "critical": {
+            "fg": "#e27878",
+            "bg": "#c6c8d1"
+        }
+    },
+    "cycle": [
+        { "fg": "#161821", "bg": "#e2a478" },
+        { "fg": "#161821", "bg": "#e27878" },
+        { "fg": "#161821", "bg": "#b4be82" },
+        { "fg": "#161821", "bg": "#89b8c2" },
+        { "fg": "#161821", "bg": "#84a0c6" },
+        { "fg": "#161821", "bg": "#a093c7" }
+    ],
+    "dnf": {
+        "good": {
+            "fg": "#b4be82",
+            "bg": "#161821"
+        }
+    },
+    "pacman": {
+        "good": {
+            "fg": "b4be82",
+            "bg": "#161821"
+        }
+    },
+    "battery": {
+        "charged": {
+            "fg": "#b4be82",
+            "bg": "#161821"
+        },
+        "AC": {
+            "fg": "#89b8c2",
+            "bg": "#c6c8d1"
+        }
+    }
+}


### PR DESCRIPTION
Added a theme similar to the iceberg theme for VIM by cocopon
(https://github.com/cocopon/iceberg.vim).

![iceberg-powerline](https://user-images.githubusercontent.com/39431903/45298589-457db700-b509-11e8-9a0d-5a4d72eeb2b4.png)

Hope you like it :smile: 