### PR TITLE
Add xkcd module

### DIFF
--- a/bumblebee/modules/xkcd.py
+++ b/bumblebee/modules/xkcd.py
@@ -1,0 +1,17 @@
+#pylint: disable=C0111,R0903
+
+"""Opens a random xkcd comic in the browser."""
+
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        super(Module, self).__init__(engine, config,
+                bumblebee.output.Widget(full_text="xkcd")
+        )
+        engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE,
+                cmd="xdg-open https://c.xkcd.com/random/comic/"
+        )


### PR DESCRIPTION
Added a module that opens a random xkcd comic in the default browser when clicked.

It's a bit silly but I think it might be fun 😄 Close the PR if you don't want to include it 😆 

It requires `xdg-utils` to work.