### PR TITLE
Return 0 as an int rather than a string.

### DIFF
--- a/bumblebee/modules/arch-update.py
+++ b/bumblebee/modules/arch-update.py
@@ -27,7 +27,7 @@ class Module(bumblebee.engine.Module):
             packages.pop()
 
             return len(packages)
-        return '0'
+        return 0
 
     def utilization(self, widget):
         return 'Update Arch: {}'.format(self.packages)


### PR DESCRIPTION
This was causing an ocassional crash in bumblebee/engine.py threshold_state
when 'checkupdates' fails, perhaps due to wifi not being up yet.

For me this showed up regularly on login.