### PR TITLE
Fix the arch icon.

### DIFF
--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -125,7 +125,7 @@
 		"repeat-off": { "prefix": "" }
 	},
 	"arch-update": {
-		"prefix": ""
+		"prefix": ""
 	},
 	"github": {
 		"prefix": "  "


### PR DESCRIPTION
On my current Arch Linux system, arch-update was using this arch icon:


Which I just can't find anywhere. It doesn't work on my system with any
of the full patched nerd-fonts installed.

Switching to this icon works:


I'm not sure what the original intention was with that icon/glyph?