### PR TITLE
Switch download cloud glyph for arch-update

### DIFF
--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -125,7 +125,7 @@
 		"repeat-off": { "prefix": "" }
 	},
 	"arch-update": {
-		"prefix": ""
+		"prefix": " "
 	},
 	"github": {
 		"prefix": "  "


### PR DESCRIPTION
I couldn't make the previous one work on Arch Linux with either
the ttf-awesomefont package or the ttf-awesomefont-4 AUR.

The former sorta worked, but then showed two other broken glyph
on either side of the cloud. The latter only has a broken glyph.

This one comes from nerd-font and seems to work for me.

I hope this still meets the intention of the previous one.