### PR TITLE
Use the parameter format to determine the minwidth

### DIFF
--- a/bumblebee/modules/cpu.py
+++ b/bumblebee/modules/cpu.py
@@ -20,8 +20,8 @@ import bumblebee.engine
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
         widget = bumblebee.output.Widget(full_text=self.utilization)
-        widget.set("theme.minwidth", "99.9%")
         super(Module, self).__init__(engine, config, widget)
+        widget.set("theme.minwidth", self._format.format(10.0-10e-20))
         self._utilization = psutil.cpu_percent(percpu=False)
         engine.input.register_callback(self, button=bumblebee.input.LEFT_MOUSE,
                                        cmd="gnome-system-monitor")


### PR DESCRIPTION
## Description
I changed by cpu.format to be 10% instead of 10.4% and there was a bunch of extra space in that module. The minwidth is being set by "99.9%". So I changed it to use the _format to format the minwidth instead.

## Verification

Default:
```
./bumblebee-status -m cpu -t solarized | grep min_width
"min_width": "10.0%AAAAAA"
```

Default Format:
```
./bumblebee-status -m cpu -p cpu.format="{}" -t solarized | grep min_width
"min_width": "10.0AAAAAA"
```

No Decimals:
```
./bumblebee-status -m cpu -p cpu.format="{:02.0f}%" -t solarized | grep min_width
"min_width": "10%AAAAAA"
```

Many Decimals:
```
 ./bumblebee-status -m cpu -p cpu.format="{:02.8f}%" -t solarized | grep min_width
"min_width": "10.00000000%AAAAAA"
```

I don't know where the AAAAAAA is coming from, but my guess is it's coming from the theme?

## Conclusion
I think this represents what was intended a little closer. I didn't go looking for other places where this might be a problem, and I didn't look to see if maybe you had a better way to handle formatting on newer modules.