### PR TITLE
[modules/spaceapi] Fix ArgumentException

### DIFF
--- a/bumblebee/modules/spaceapi.py
+++ b/bumblebee/modules/spaceapi.py
@@ -67,7 +67,7 @@ class Module(bumblebee.engine.Module):
 
     def update(self, widgets):
         try:
-            with requests.get(self._url, timeout=self.timeout) as u:
+            with requests.get(self._url, timeout=self._timeout) as u:
                 json = u.json()
                 self._open = json["state"]["open"]
                 self._name = self.parameter("name", default=json["space"])


### PR DESCRIPTION
I'm a little embarrassed to admit that this actually happened and went unnoticed for so long :/

---
This ArgumentException was caused by me failing to rename one occurence
of a parameter when refactoring code. This went under my radar as the
API I'm usually testing against, was offline at that time, too. So I
expceted to see an Error. Just not this one.

Well, the fix comes late, but better late than never :)

Merry Christmas :christmas_tree: 

Signed-off-by: Tobias Manske <tobias.manske@mailbox.org>