### PR TITLE
Detect wireguard interfaces as tunnel type

### DIFF
--- a/bumblebee/modules/nic.py
+++ b/bumblebee/modules/nic.py
@@ -63,7 +63,7 @@ class Module(bumblebee.engine.Module):
         return False
 
     def _istunnel(self, intf):
-        return intf.startswith("tun")
+        return intf.startswith("tun") or intf.startswith("wg")
 
     def get_addresses(self, intf):
         retval = []
@@ -74,7 +74,7 @@ class Module(bumblebee.engine.Module):
         except Exception:
             return []
         return retval
-    
+
     def _update_widgets(self, widgets):
         interfaces = [i for i in netifaces.interfaces() if not i.startswith(self._exclude)]
 
@@ -90,7 +90,7 @@ class Module(bumblebee.engine.Module):
 
             if len(self._states["exclude"]) > 0 and state in self._states["exclude"]: continue
             if len(self._states["include"]) > 0 and state not in self._states["include"]: continue
-            
+
             widget = self.widget(intf)
             if not widget:
                 widget = bumblebee.output.Widget(name=intf)
@@ -104,7 +104,7 @@ class Module(bumblebee.engine.Module):
         for widget in widgets:
             if widget.get("visited") is False:
                 widgets.remove(widget)
-    
+
     def get_ssid(self, intf):
         if self._iswlan(intf):
             try:


### PR DESCRIPTION
I started playing around with wireguard a bit and it annoyed me that the interface was marked as wireless. So I added just a simple check for the default interface name which is wg<number>