### PR TITLE
small improvement in pi-hole module

### DIFF
--- a/bumblebee/modules/pihole.py
+++ b/bumblebee/modules/pihole.py
@@ -30,7 +30,7 @@ class Module(bumblebee.engine.Module):
 
     def pihole_status(self, widget):
         if self._pihole_status is None:
-            return "unknown"
+            return "pi-hole unknown"
         return "pi-hole " + ("up/" + self._ads_blocked_today if self._pihole_status else "down")
 
     def update_pihole_status(self):
@@ -61,8 +61,8 @@ class Module(bumblebee.engine.Module):
         self.update_pihole_status()
 
     def state(self, widget):
-        if self._pihole_status:
+        if self._pihole_status is None:
+            return []
+        elif self._pihole_status:
             return ["enabled"]
-        elif not self._pihole_status:
-            return ["disabled", "warning"]
-        return []
+        return ["disabled", "warning"]


### PR DESCRIPTION
This pull request sets the status to 'pi-hole unknown' in case the pi-hole status cannot be retrieved.

Up to now, the state was set to 'pi-hole down' (with a warning), in case the status couldn't be retrieved from the pi-hole instance. This is especially annoying right after boot, when there is no IP address is assigned via DHCP and bumblebee already tries to ping the pi-hole instance. In that case, the pi-hole instance was always marked as 'down', although it was up. This pull request fixes that. 

In general, it would probably be the nicest solution to distinguish between 'pi-hole is really down' and 'it's network problem on the host (iface down, no route, etc)'. But I guess, in case pi-hole is really down (meaning not responsive, powered down etc) you most probably recognize it anyways ;-).  

So I think it should be okay to use the 'up' and 'down' state solely for representing 'blocking is active' and 'blocking is disabled'.  
