### PR TITLE
Add support for city ids to weather module.

### DIFF
--- a/bumblebee/modules/weather.py
+++ b/bumblebee/modules/weather.py
@@ -7,8 +7,9 @@ Requires the following python packages:
     * requests
 
 Parameters:
-    * weather.location: Set location (ISO 3166 country code), defaults to 'auto' for getting location from http://ipinfo.io
-                        If set to a comma-separated list, left-click and right-click can be used to rotate the locations
+    * weather.location: Set location, defaults to 'auto' for getting location from http://ipinfo.io
+                        If set to a comma-separated list, left-click and right-click can be used to rotate the locations.
+                        Locations should be city names or city ids.
     * weather.unit: metric (default), kelvin, imperial
     * weather.showcity: If set to true, show location information, otherwise hide it (defaults to true)
     * weather.apikey: API key from http://api.openweathermap.org
@@ -107,12 +108,13 @@ class Module(bumblebee.engine.Module):
                 location_url = "http://ipinfo.io/json"
                 location = requests.get(location_url).json()
                 coord = location["loc"].split(",")
-                self._city = location["city"]
                 weather_url = "{url}&lat={lat}&lon={lon}".format(url=weather_url, lat=coord[0], lon=coord[1])
+            elif self._location[self._index].isdigit():
+                weather_url = "{url}&id={id}".format(url=weather_url, id=self._location[self._index])
             else:
-                self._city = self._location[self._index]
                 weather_url = "{url}&q={city}".format(url=weather_url, city=self._location[self._index])
             weather = requests.get(weather_url).json()
+            self._city = weather['name']
             self._temperature = int(weather['main']['temp'])
             self._weather = weather['weather'][0]['main'].lower()
             self._valid = True


### PR DESCRIPTION
Some cities (e.g. in different countries) have the same names (e.g. [Oxford](https://openweathermap.org/find?q=Oxford)). Providing a city name to the weather module would previously display the first returned result by openweathermap's API.

This commit allows city ids to be provided to the weather module. If a location passed to the weather module only contains numbers, it will be interpreted as a city id. City ids are those handled by openweathermap's API to uniquely identify cities.

See https://openweathermap.org/current#cityid for details.