### PR TITLE
fixed bug in bumblebee popup implementation

### DIFF
--- a/bumblebee/popup.py
+++ b/bumblebee/popup.py
@@ -43,7 +43,7 @@ class PopupMenu:
         if callback is None:
             callback = click_callback
         self.menu.add_command(label=menuitem,
-                              command=click_callback)
+                              command=callback)
 
         # track item index
         self._item_count += 1


### PR DESCRIPTION
Please correct me if I am wrong, but I _think_ there is a typo in the popup implementation. It should be `command=callback` instead of `command=click_callback`.