### PR TITLE
reworked PopupMenu implementation

### DIFF
--- a/bumblebee/popup_v2.py
+++ b/bumblebee/popup_v2.py
@@ -1,0 +1,38 @@
+"""Pop-up menus."""
+
+try:
+    import Tkinter as tk
+except ImportError:
+    # python 3
+    try:
+        import tkinter as tk
+    except ImportError:
+        pass
+
+import functools
+
+
+class PopupMenu(object):
+    def __init__(self):
+        self._root = tk.Tk()
+        self._root.withdraw()
+        self._menu = tk.Menu(self._root)
+        self._menu.bind("<FocusOut>", self._on_focus_out)
+
+    def _on_focus_out(self, event=None):
+        self._root.destroy()
+
+    def _on_click(self, callback):
+        self._root.destroy()
+        callback()
+
+
+    def add_menuitem(self, menuitem, callback):
+        self._menu.add_command(label=menuitem, command=functools.partial(self._on_click, callback))
+
+    def show(self, event):
+        try:
+            self._menu.tk_popup(event['x'], event['y'])
+        finally:
+            self._menu.grab_release()
+        self._root.mainloop()


### PR DESCRIPTION
I tried to stay API wise as compatible as possible to the old implementation, although I have to admit that I didn't fully understand the old implementation - so I can't rule out that this implementation is missing something that the old implementation had baked in. 

Although I have tried to stay as compatible as possible, there are a few subtle changes to the API: 

* the `show()` method doesn't return anything
* the `callback` parameter in the `add_menuitem` function doesn't default to `None` anymore (I couldn't come up with a use case where it makes sense to add a menu item without a callback; but maybe I am missing something here ;))

(I also removed the `create_and_show_menu` function, as it seems to be not used anymore?)

Due to those subtle changes, it is unfortunately not a drop in replacement for the old bumblebee PopupMenu. But as far as I've seen the only module that's using the bumblebee PopupMenu is the `bluetooth` module. I guess changing the bluetooth module shouldn't be too much work :)

Feel free to change, improve, discard this pull request. I am by no means a tkinter expert, but it seems to be working now (at least on my machine ;)) 

edit: looks like this implementation has indeed a drawback: it's not possible anymore to close the popup menu by clicking outside of the menu. Personally I do not care much about that, but it changes the original behavior :/ 

I played a bit around but I couldn't make it work (at least with tkinter alone). I am not a tkinter expert, but to me this seems to be an architectural problem: As far as I know, tkinter can only bind to widgets and deal with events that occur within those widgets. But in order to catch clicks outside the menu widget, one would need to catch mouse clicks outside the root/menu widget which seems to be not possible with tkinter (at least I haven't found it). 

Not sure if it would work, but maybe it would be possible to create a fullscreen transparent root widget (which catches all the mouse clicks outside the menu widget) and put the popup menu on top of that. But that sounds...well...a bit hackish. 

I am still hoping there is an easy solution for that which I completely missed ,)