### PR TITLE
[module] Basic alternate network traffic module

### DIFF
--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -1,0 +1,42 @@
+"""Displays network traffic
+"""
+
+import psutil
+import netifaces
+import bytefmt
+
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        super(Module, self).__init__(engine, config,
+            bumblebee.output.Widget(full_text=self.utilization)
+        )
+
+        self._default_adapter = netifaces.gateways()['default'][netifaces.AF_INET][1]
+
+        self._download_tx, self._upload_tx = self.network_tx()
+
+    def utilization(self, widget):
+        return "{0} {1}".format(
+            bytefmt.humanize(self._final_download_tx),
+            bytefmt.humanize(self._final_upload_tx)
+        )
+
+    def update(self, widgets):
+        download_tx, upload_tx = self.network_tx() 
+        
+        self._final_download_tx = (download_tx - self._download_tx)
+        self._final_upload_tx = (upload_tx - self._upload_tx)
+
+        self._download_tx, self._upload_tx = download_tx, upload_tx
+
+    def network_tx(self):
+        io_counters = psutil.net_io_counters(pernic=True)
+        network = io_counters[self._default_adapter]
+
+        return network.bytes_recv, network.bytes_sent
+
+

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -16,21 +16,27 @@ class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
         super(Module, self).__init__(engine, config)
 
-        self._bandwidth = BandwidthInfo()
+        try:
+            self._bandwidth = BandwidthInfo()
 
-        self._download_tx = self._bandwidth.bytes_recv()
-        self._upload_tx = self._bandwidth.bytes_sent()
+            self._download_tx = self._bandwidth.bytes_recv()
+            self._upload_tx = self._bandwidth.bytes_sent()
+        except:
+            pass
 
     def update(self, widgets):
-        download_tx = self._bandwidth.bytes_recv()
-        upload_tx = self._bandwidth.bytes_sent()
+        try:
+            download_tx = self._bandwidth.bytes_recv()
+            upload_tx = self._bandwidth.bytes_sent()
 
-        download_rate = (download_tx - self._download_tx)
-        upload_rate = (upload_tx - self._upload_tx)
+            download_rate = (download_tx - self._download_tx)
+            upload_rate = (upload_tx - self._upload_tx)
 
-        self.update_widgets(widgets, download_rate, upload_rate)
+            self.update_widgets(widgets, download_rate, upload_rate)
 
-        self._download_tx, self._upload_tx = download_tx, upload_tx
+            self._download_tx, self._upload_tx = download_tx, upload_tx
+        except:
+            pass
 
     def update_widgets(self, widgets, download_rate, upload_rate):
         del widgets[:]
@@ -43,8 +49,7 @@ class Module(bumblebee.engine.Module):
 
 class BandwidthInfo(object):
     def __init__(self):
-        io_counters = self.io_counters()
-        self.network = io_counters[self.default_network_adapter()]
+        self.bandwidth()
 
     def bytes_recv(self):
         return self.bandwidth().bytes_recv
@@ -57,8 +62,12 @@ class BandwidthInfo(object):
         return io_counters[self.default_network_adapter()]
 
     def default_network_adapter(self):
-        gateways = netifaces.gateways()
-        return gateways['default'][netifaces.AF_INET][1]
+        gateway = netifaces.gateways()['default']
+
+        if (len(gateway) == 0):
+            raise 'No default gateway found'
+
+        return gateway[netifaces.AF_INET][1]
 
     def io_counters(self):
         return psutil.net_io_counters(pernic=True)

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -3,40 +3,73 @@
 
 import psutil
 import netifaces
-import bytefmt
 
 import bumblebee.input
 import bumblebee.output
 import bumblebee.engine
+import bumblebee.util
 
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
-        super(Module, self).__init__(engine, config,
-            bumblebee.output.Widget(full_text=self.utilization)
-        )
+        super(Module, self).__init__(engine, config)
 
-        self._default_adapter = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        self._bandwidth = BandwidthInfo()
 
-        self._download_tx, self._upload_tx = self.network_tx()
-
-    def utilization(self, widget):
-        return "{0} {1}".format(
-            bytefmt.humanize(self._final_download_tx),
-            bytefmt.humanize(self._final_upload_tx)
-        )
+        self._download_tx = self._bandwidth.bytes_recv()
+        self._upload_tx = self._bandwidth.bytes_sent()
 
     def update(self, widgets):
-        download_tx, upload_tx = self.network_tx() 
-        
-        self._final_download_tx = (download_tx - self._download_tx)
-        self._final_upload_tx = (upload_tx - self._upload_tx)
+        download_tx = self._bandwidth.bytes_recv()
+        upload_tx = self._bandwidth.bytes_sent()
+
+        download_rate = (download_tx - self._download_tx)
+        upload_rate = (upload_tx - self._upload_tx)
+
+        self.update_widgets(widgets, download_rate, upload_rate)
 
         self._download_tx, self._upload_tx = download_tx, upload_tx
 
-    def network_tx(self):
-        io_counters = psutil.net_io_counters(pernic=True)
-        network = io_counters[self._default_adapter]
+    def update_widgets(self, widgets, download_rate, upload_rate):
+        del widgets[:]
 
-        return network.bytes_recv, network.bytes_sent
+        widgets.extend((
+            TrafficWidget(download_rate, ''),
+            TrafficWidget(upload_rate, '')
+        ))
 
 
+class BandwidthInfo:
+    def __init__(self):
+        io_counters = self.io_counters()
+        self.network = io_counters[self.default_network_adapter()]
+
+    def bytes_recv(self):
+        return self.bandwidth().bytes_recv
+
+    def bytes_sent(self):
+        return self.bandwidth().bytes_sent
+
+    def bandwidth(self):
+        io_counters = self.io_counters()
+        return io_counters[self.default_network_adapter()]
+
+    def default_network_adapter(self):
+        gateways = netifaces.gateways()
+        return gateways['default'][netifaces.AF_INET][1]
+
+    def io_counters(self):
+        return psutil.net_io_counters(pernic=True)
+
+
+class TrafficWidget:
+    def __new__(self, text, icon):
+        widget = bumblebee.output.Widget()
+        widget.set('theme.minwidth', '00000000KiB/s')
+        widget.full_text(self.humanize(text, icon))
+
+        return widget
+
+    @staticmethod
+    def humanize(text, icon):
+        humanized_byte_format = bumblebee.util.bytefmt(text)
+        return '{0} {1}/s'.format(icon, humanized_byte_format)

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """Displays network traffic
-No extra configuratio needed.
+   * No extra configuration needed
 """
 
 import psutil

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -41,7 +41,7 @@ class Module(bumblebee.engine.Module):
         ))
 
 
-class BandwidthInfo:
+class BandwidthInfo(object):
     def __init__(self):
         io_counters = self.io_counters()
         self.network = io_counters[self.default_network_adapter()]
@@ -64,7 +64,7 @@ class BandwidthInfo:
         return psutil.net_io_counters(pernic=True)
 
 
-class TrafficWidget:
+class TrafficWidget(object):
     def __new__(self, text, icon):
         widget = bumblebee.output.Widget()
         widget.set('theme.minwidth', '00000000KiB/s')

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -48,9 +48,6 @@ class Module(bumblebee.engine.Module):
 
 
 class BandwidthInfo(object):
-    def __init__(self):
-        self.bandwidth()
-
     def bytes_recv(self):
         return self.bandwidth().bytes_recv
 

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """Displays network traffic
 """
 

--- a/bumblebee/modules/network_traffic.py
+++ b/bumblebee/modules/network_traffic.py
@@ -33,8 +33,8 @@ class Module(bumblebee.engine.Module):
         del widgets[:]
 
         widgets.extend((
-            TrafficWidget(download_rate, ''),
-            TrafficWidget(upload_rate, '')
+            TrafficWidget(text=download_rate, icon=''),
+            TrafficWidget(text=upload_rate, icon='')
         ))
 
 

--- a/themes/icons/ascii.json
+++ b/themes/icons/ascii.json
@@ -92,6 +92,10 @@
 		"rx": { "prefix": "down"},
 		"tx": { "prefix": "up"}
 	},
+	"network_traffic": {
+		"rx": { "prefix": "down" },
+		"tx": { "prefix": "up" }
+	},
     "mpd": {
 		"playing": { "prefix": ">" },
 		"paused": { "prefix": "||" },

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -145,6 +145,10 @@
 	    "rx": { "prefix": "" },
 	    "tx": { "prefix": "" }
     },
+    "network_traffic": {
+	    "rx": { "prefix": "" },
+            "tx": { "prefix": "" }
+    },
     "mpd": {
 		"playing": { "prefix": "" },
 		"paused": { "prefix": "" },

--- a/themes/icons/ionicons.json
+++ b/themes/icons/ionicons.json
@@ -129,6 +129,10 @@
 	  "rx": { "prefix": "\uf365" },
 	  "tx": { "prefix": "\uf35f" }
   },
+  "network_traffic": {
+	  "rx": { "prefix": "\uf365" },
+	  "tx": { "prefix": "\uf35f" }
+  },
   "mpd": {
 		"playing": { "prefix": "\uf488" },
 		"paused": { "prefix": "\uf210" },


### PR DESCRIPTION
In this PR I'm proposing an alternate network traffic module.

Main differences between this and the default traffic module:
- No extra configurations
- Easy to use
- Get information from the default network adapter

#### Usage

No extra configuration needed. Just `-m network_traffic`.

I have been using this module for 3 months+ and it's working very well.

#### Dependencies

* psutil
* netifaces

#### Tests

I would like to implement some unit tests, but it's kinda hard to mock a network adapter. I think I will need to rewrite some classes using dependency injection later. I hope I could cover this module in future.

#### Screenshot

![ss](https://user-images.githubusercontent.com/1095412/57658713-43975680-75b6-11e9-8263-612f41364e05.gif)