### PR TITLE
find aliases without importing modules

### DIFF
--- a/bumblebee/engine.py
+++ b/bumblebee/engine.py
@@ -16,6 +16,16 @@ try:
 except ImportError:
     from configparser import RawConfigParser
 
+def all_modules():
+    """Return a list of available modules"""
+    result = []
+    path = os.path.dirname(bumblebee.modules.__file__)
+    for mod in [name for _, name, _ in pkgutil.iter_modules([path])]:
+        result.append({
+            "name": mod
+        })
+    return result
+  
 class Module(object):
     """Module instance base class
 

--- a/bumblebee/engine.py
+++ b/bumblebee/engine.py
@@ -16,16 +16,6 @@ try:
 except ImportError:
     from configparser import RawConfigParser
 
-def all_modules():
-    """Return a list of available modules"""
-    result = []
-    path = os.path.dirname(bumblebee.modules.__file__)
-    for mod in [name for _, name, _ in pkgutil.iter_modules([path])]:
-        result.append({
-            "name": mod
-        })
-    return result
-
 class Module(object):
     """Module instance base class
 
@@ -231,14 +221,25 @@ class Engine(object):
                     button=button["id"], cmd=module.parameter(button["name"]))
 
     def _read_aliases(self):
+        """Retruns a dictionary that maps every alias to its real module name"""
         result = {}
-        for module in all_modules():
+        m_path = os.path.abspath(bumblebee.modules.__file__)
+        m_path = os.path.dirname(m_path)
+        ALIASES_PATH = m_path + "/aliases/"
+        for name in os.listdir(ALIASES_PATH):
             try:
-                mod = importlib.import_module("bumblebee.modules.{}".format(module["name"]))
-                for alias in getattr(mod, "ALIASES", []):
-                    result[alias] = module["name"]
+                # listdir does not retur full paths
+                f_path = ALIASES_PATH + name
+                # skip any directory
+                if not os.path.isfile(f_path): continue
+                with open(f_path) as f:
+                    for alias in f.readlines():
+                        alias = alias.strip()
+                        # skip empty lines
+                        if len(alias) == 0: continue
+                        result[alias] = name 
             except Exception as error:
-                log.warning("failed to import {}: {}".format(module["name"], str(error)))
+                log.warning("failed to load aliases of {}: {}".format(name, str(error)))
         return result
 
     def _load_module(self, module_name, config_name=None):

--- a/bumblebee/modules/aliases/datetime
+++ b/bumblebee/modules/aliases/datetime
@@ -1,0 +1,2 @@
+date
+time

--- a/bumblebee/modules/aliases/datetimetz
+++ b/bumblebee/modules/aliases/datetimetz
@@ -1,0 +1,2 @@
+datetz
+timetz

--- a/bumblebee/modules/aliases/pulseaudio
+++ b/bumblebee/modules/aliases/pulseaudio
@@ -1,0 +1,2 @@
+pasink
+pasource

--- a/bumblebee/modules/aliases/test
+++ b/bumblebee/modules/aliases/test
@@ -1,0 +1,1 @@
+test-alias

--- a/bumblebee/modules/datetime.py
+++ b/bumblebee/modules/datetime.py
@@ -16,8 +16,6 @@ import datetime
 import locale
 import bumblebee.engine
 
-ALIASES = ["date", "time"]
-
 def default_format(module):
     default = "%x %X"
     if module == "date":

--- a/bumblebee/modules/datetimetz.py
+++ b/bumblebee/modules/datetimetz.py
@@ -26,8 +26,6 @@ import bumblebee.input
 import bumblebee.output
 import bumblebee.engine
 
-ALIASES = ["datetz", "timetz"]
-
 def default_format(module):
     default = "%x %X %Z"
     if module == "datetz":

--- a/bumblebee/modules/pulseaudio.py
+++ b/bumblebee/modules/pulseaudio.py
@@ -24,8 +24,6 @@ import bumblebee.input
 import bumblebee.output
 import bumblebee.engine
 
-ALIASES = ["pasink", "pasource"]
-
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
         super(Module, self).__init__(engine, config,

--- a/bumblebee/modules/test.py
+++ b/bumblebee/modules/test.py
@@ -5,8 +5,6 @@
 
 import bumblebee.engine
 
-ALIASES = ["test-alias"]
-
 class Module(bumblebee.engine.Module):
     def __init__(self, engine, config):
         super(Module, self).__init__(engine, config,


### PR DESCRIPTION
currently, `engine.py` imports all the modules to load their aliases, which takes much time when bumblebee is starting and spits out errors for missing dependencies when the modules aren't actually used. to prevent this I separated the aliases form the python modules, so they can be loaded apart from them.