### PR TITLE
Add support for nowplaying-tf in deadbeef module

### DIFF
--- a/bumblebee/modules/deadbeef.py
+++ b/bumblebee/modules/deadbeef.py
@@ -1,22 +1,38 @@
 # pylint: disable=C0111,R0903
 
-"""Displays the current song being played in DeaDBeeF and
-provides some media control bindings.
-Left click toggles pause, scroll up skips the current song,
-scroll down returns to the previous song.
+"""Displays the current song being played in DeaDBeeF and provides
+some media control bindings.
+Left click toggles pause, scroll up skips the current song, scroll
+down returns to the previous song.
+
 Requires the following library:
     * subprocess
 Parameters:
-    * deadbeef.format:   Format string (defaults to "{artist} - {title}")
-                         Available values are: {artist}, {title}, {album}, {length},
-                                               {trackno}, {year}, {comment},
-                                               {copyright}, {time}
-    * deadbeef.previous: Change binding for previous song (default is left click)
-    * deadbeef.next:     Change binding for next song (default is right click)
-    * deadbeef.pause:    Change binding for toggling pause (default is middle click)
+    * deadbeef.format:    Format string (defaults to "{artist} - {title}")
+                          Available values are: {artist}, {title}, {album}, {length},
+                                                {trackno}, {year}, {comment},
+                                                {copyright}, {time}
+                          This is deprecated, but much simpler.
+    * deadbeef.tf_format: A foobar2000 title formatting-style format string.
+                          These can be much more sophisticated than the standard
+                          format strings. This is off by default, but specifying
+                          any tf_format will enable it. If both deadbeef.format
+                          and deadbeef.tf_format are specified, deadbeef.tf_format
+                          takes priority.
+    * deadbeef.tf_format_if_stopped: Controls whether or not the tf_format format
+                          string should be displayed even if no song is paused or
+                          playing. This could be useful if you want to implement
+                          your own stop strings with the built in logic. Any non-
+                          null value will enable this (by default the module will
+                          hide itself when the player is stopped).
+    * deadbeef.previous:  Change binding for previous song (default is left click)
+    * deadbeef.next:      Change binding for next song (default is right click)
+    * deadbeef.pause:     Change binding for toggling pause (default is middle click)
     Available options for deadbeef.previous, deadbeef.next and deadbeef.pause are:
         LEFT_CLICK, RIGHT_CLICK, MIDDLE_CLICK, SCROLL_UP, SCROLL_DOWN
+
 """
+import sys
 
 import bumblebee.input
 import bumblebee.output
@@ -34,54 +50,88 @@ class Module(bumblebee.engine.Module):
         super(Module, self).__init__(engine, config,
                                      bumblebee.output.Widget(full_text=self.deadbeef)
                                      )
-        buttons = {"LEFT_CLICK":bumblebee.input.LEFT_MOUSE,
-                   "RIGHT_CLICK":bumblebee.input.RIGHT_MOUSE,
-                   "MIDDLE_CLICK":bumblebee.input.MIDDLE_MOUSE,
-                   "SCROLL_UP":bumblebee.input.WHEEL_UP,
-                   "SCROLL_DOWN":bumblebee.input.WHEEL_DOWN,
+        buttons = {"LEFT_CLICK": bumblebee.input.LEFT_MOUSE,
+                   "RIGHT_CLICK": bumblebee.input.RIGHT_MOUSE,
+                   "MIDDLE_CLICK": bumblebee.input.MIDDLE_MOUSE,
+                   "SCROLL_UP": bumblebee.input.WHEEL_UP,
+                   "SCROLL_DOWN": bumblebee.input.WHEEL_DOWN,
                    }
         
         self._song = ""
         self._format = self.parameter("format", "{artist} - {title}")
+        self._tf_format = self.parameter("tf_format", "")
+        self._show_tf_when_stopped = bool(self.parameter("tf_format_if_stopped", ""))
         prev_button = self.parameter("previous", "LEFT_CLICK")
         next_button = self.parameter("next", "RIGHT_CLICK")
         pause_button = self.parameter("pause", "MIDDLE_CLICK")
 
-        self.now_playing = ["deadbeef","--nowplaying","%a;%t;%b;%l;%n;%y;%c;%r;%e"]
+        self.now_playing = ["deadbeef", "--nowplaying", "%a;%t;%b;%l;%n;%y;%c;%r;%e"]
+        self.now_playing_tf = ["deadbeef", "--nowplaying-tf", ""]
         cmd = "deadbeef "
-        
+
         engine.input.register_callback(self, button=buttons[prev_button],
-            cmd=cmd + "--prev")
+                                       cmd=cmd + "--prev")
         engine.input.register_callback(self, button=buttons[next_button],
-            cmd=cmd + "--next")
+                                       cmd=cmd + "--next")
         engine.input.register_callback(self, button=buttons[pause_button],
-            cmd=cmd + "--play-pause")
+                                       cmd=cmd + "--play-pause")
 
     @scrollable
     def deadbeef(self, widget):
-        return str(self._song)
+        return self.string_song
 
     def hidden(self):
-        return str(self._song) == ""
+        return self.string_song == ""
 
     def update(self, widgets):
         try:
-            deadbeef = subprocess.Popen(self.now_playing,stdin=subprocess.PIPE,stdout=subprocess.PIPE)
-            data = deadbeef.communicate()[0]
-            if data == "nothing":
-                self._song = ""
-            else:
-                data = data.split(";")
-                self._song = self._format.format(artist=data[0],
-                                                 title=data[1],
-                                                 album=data[2],
-                                                 length=data[3],
-                                                 trackno=data[4],
-                                                 year=data[5],
-                                                 comment=data[6],
-                                                 copyright=data[7],
-                                                 time=data[8])
+            if self._tf_format == "": # no tf format set, use the old style
+                return self.update_standard(widgets)
+            return self.update_tf(widgets)
         except Exception:
+            self._song = "error"
+
+    def update_tf(self, widgets):
+        if not self._show_tf_when_stopped:
+            ## check if the player is paused or playing
+            self.now_playing_tf[-1] = "%isplaying%%ispaused%"
+            data = read_process(self.now_playing_tf)
+            if data == "":
+                self._song = ""
+                return
+        ## perform the actual query -- these can be much more sophisticated
+        self.now_playing_tf[-1] = self._tf_format
+        data = read_process(self.now_playing_tf)
+        self._song = data
+
+    def update_standard(self, widgets):
+        data = read_process(self.now_playing)
+        if data == "nothing":
             self._song = ""
+        else:
+            data = data.split(";")
+            self._song = self._format.format(artist=data[0],
+                                             title=data[1],
+                                             album=data[2],
+                                             length=data[3],
+                                             trackno=data[4],
+                                             year=data[5],
+                                             comment=data[6],
+                                             copyright=data[7],
+                                             time=data[8])
+
+    @property
+    def string_song(self):
+        """\
+Returns the current song as a string, either as a unicode() (Python <
+3) or a regular str() (Python >= 3)
+        """
+        if sys.version_info.major < 3:
+            return unicode(self._song)
+        return str(self._song)
+
+def read_process(command):
+    proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    return proc.stdout.read()
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This allows more sophisticated queries in the same style as foobar2000's title formatting queries. This massively increases the customisability of the module text as it is generated entirely by deadbeef, rather than by the module, and supports various arithmetic and control operations. 

The module should also properly support unicode text now, regardless of python version.

I've also done a few bits of clean-up on the module where I can, my code isn't always the most readable and emacs loves to complain about it :^)