### PR TITLE
Bluetooth module: dbus object path and popup menu

### DIFF
--- a/bumblebee/modules/bluetooth.py
+++ b/bumblebee/modules/bluetooth.py
@@ -5,6 +5,7 @@ Parameters:
     * bluetooth.device : the device to read state from (default is hci0)
     * bluetooth.manager : application to launch on click (blueman-manager)
     * bluetooth.dbus_destination : dbus destination (defaults to org.blueman.Mechanism)
+    * bluetooth.dbus_destination_path : dbus destination path (defaults to /)
 
 """
 
@@ -97,10 +98,11 @@ class Module(bumblebee.engine.Module):
             state = "true"
 
         dst = self.parameter("dbus_destination", "org.blueman.Mechanism")
+        dst_path = self.parameter("dbus_destination_path", "/")
 
         cmd = "dbus-send --system --print-reply --dest={}"\
-              " / org.blueman.Mechanism.SetRfkillState"\
-              " boolean:{}".format(dst, state)
+              " {} org.blueman.Mechanism.SetRfkillState"\
+              " boolean:{}".format(dst, dst_path, state)
 
         bumblebee.util.execute(cmd)
 


### PR DESCRIPTION
This PR has two modifications in the module ***bluetooth***:

1. Fix #483 
  The cause of #483 is the path to blueman D-Bus object. By default, the path is hard-coded to `/`. This PR adds a parameter to configure this path. The parameter added is `bluetooth.dbus_destination_path`. And the default value is `/`.

2. Allow users to disable popup menu
  The default behavior of a right-click is to pop up a graphical menu. But the graphical menu does not work well in [Sway WM](https://github.com/swaywm/sway) and swaybar because of the Wayland backend. So this PR adds a parameter to control whether to use the graphical menu or not. If `bluetooth.right_click_popup` is `True` (default), a menu pops up, just like before. If `bluetooth.right_click_popup=False`, a right-click will simply turn on/off the bluetooth device without any menu.