### PR TITLE
Improve battery-upower

### DIFF
--- a/bumblebee/modules/arch-update.py
+++ b/bumblebee/modules/arch-update.py
@@ -1,4 +1,5 @@
-"""Check updates to Arch Linux."""
+"""Check updates to Arch Linux.
+"""
 
 
 import subprocess

--- a/themes/icons/ascii.json
+++ b/themes/icons/ascii.json
@@ -93,6 +93,45 @@
       "prefix": "tun"
     }
   },
+  "battery-upower": {
+    "charged": {
+      "suffix": "full"
+    },
+    "charging": {
+      "suffix": "chr"
+    },
+    "AC": {
+      "suffix": "ac"
+    },
+    "discharging-10": {
+      "prefix": "!",
+      "suffix": "dis"
+    },
+    "discharging-25": {
+      "suffix": "dis"
+    },
+    "discharging-50": {
+      "suffix": "dis"
+    },
+    "discharging-80": {
+      "suffix": "dis"
+    },
+    "discharging-100": {
+      "suffix": "dis"
+    },
+    "unknown-25": {
+      "suffix": "?"
+    },
+    "unknown-50": {
+      "suffix": "?"
+    },
+    "unknown-80": {
+      "suffix": "?"
+    },
+    "unknown-100": {
+      "suffix": "?"
+    }
+  },
   "battery": {
     "charged": {
       "suffix": "full"

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -82,6 +82,26 @@
     "OFF": { "prefix": "" },
     "?": { "prefix": "" }
   },
+  "battery-upower": {
+    "charged": { "prefix": "", "suffix": "" },
+    "AC": { "suffix": "" },
+    "charging": {
+      "prefix": ["", "", "", "", ""],
+      "suffix": ""
+    },
+    "discharging-10": { "prefix": "", "suffix": "" },
+    "discharging-25": { "prefix": "", "suffix": "" },
+    "discharging-50": { "prefix": "", "suffix": "" },
+    "discharging-80": { "prefix": "", "suffix": "" },
+    "discharging-100": { "prefix": "", "suffix": "" },
+    "unlimited": { "prefix": "", "suffix": "" },
+    "estimate": { "prefix": "" },
+    "unknown-10": { "prefix": "", "suffix": "" },
+    "unknown-25": { "prefix": "", "suffix": "" },
+    "unknown-50": { "prefix": "", "suffix": "" },
+    "unknown-80": { "prefix": "", "suffix": "" },
+    "unknown-100": { "prefix": "", "suffix": "" }
+  },
   "battery": {
     "charged": { "prefix": "", "suffix": "" },
     "AC": { "suffix": "" },


### PR DESCRIPTION
1. Add icons for **battery-upower**. The icons are the same set used by **battery** and **battert_all** modules.
2. Fix the parameter names in documentation
3. Fix the issue that when using `bumblebee-status -l modules`, the doc of **arch-update** and **battery-upower** are not separated by a bland line.
4. Now also show the remaining time to fully charged when charging
5. Reduce the frequency of making requests to D-Bus:
  When requesting the remaining time, we only need to request the state and time to empty (or time to full). Original code called a function `get_full_device_information`, which makes a lot of unnecessary requests to get full status. This PR eliminates this behavior by only requesting state and time to empty/time to full.