### PR TITLE
Added filtering in modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ $ ./bumblebee-status -l themes
 $ ./bumblebee-status -l modules
 ```
 
+You can also narrow you modules list using the filter at the end:
+```
+$ cd bumblebee-status
+$ ./bumblebee-status -l modules xkcd zpool
+```
+
 Any parameter you can specify with `-p <name>=<value>`, you can alternatively specify in `~/.bumblebee-status.conf` or `~/.config/bumblebee-status.conf`. This parameters act as a **fallback**, so values specified with `-p` have priority.
 
 Parameters can also be used to override theme settings, such as:

--- a/bumblebee/config.py
+++ b/bumblebee/config.py
@@ -24,26 +24,29 @@ class print_usage(argparse.Action):
         self._indent = " "*2
 
     def __call__(self, parser, namespace, value, option_string=None):
-        if value == "modules":
-            self.print_modules()
-        elif value == "themes":
+        if value[0] == "modules":
+            self.print_modules(value[1:])
+        elif value[0] == "themes":
             self.print_themes()
+        else:
+            print("Listing '" + value[0] + "' is not supported! Only 'modules' or 'themes'")
         sys.exit(0)
 
     def print_themes(self):
         print(", ".join(bumblebee.theme.themes()))
 
-    def print_modules(self):
+    def print_modules(self, modules):
         for m in bumblebee.engine.all_modules():
-            try:
-                mod = importlib.import_module("bumblebee.modules.{}".format(m["name"]))
-                print(textwrap.fill("{}:".format(m["name"]), 80,
-                        initial_indent=self._indent*2, subsequent_indent=self._indent*2))
-                for line in mod.__doc__.split("\n"):
-                    print(textwrap.fill(line, 80,
-                        initial_indent=self._indent*3, subsequent_indent=self._indent*6))
-            except:
-                pass
+            if not modules or m["name"] in modules:
+                try:
+                    mod = importlib.import_module("bumblebee.modules.{}".format(m["name"]))
+                    print(textwrap.fill("{}:".format(m["name"]), 80,
+                            initial_indent=self._indent*2, subsequent_indent=self._indent*2))
+                    for line in mod.__doc__.split("\n"):
+                        print(textwrap.fill(line, 80,
+                            initial_indent=self._indent*3, subsequent_indent=self._indent*6))
+                except:
+                    pass
 
 def create_parser():
     """Create the argument parser"""
@@ -54,7 +57,7 @@ def create_parser():
     parser.add_argument("--markup", default="none", help="Specify the markup type of the output (e.g. 'pango')")
     parser.add_argument("-p", "--parameters", nargs="+", action='append', default=[],
         help=PARAMETER_HELP)
-    parser.add_argument("-l", "--list", choices=["modules", "themes"], action=print_usage,
+    parser.add_argument("-l", "--list", nargs='+', action=print_usage,
         help=LIST_HELP)
     parser.add_argument("-d", "--debug", action="store_true",
         help=DEBUG_HELP)


### PR DESCRIPTION
This filters the modules list

An bug that I couldn't solve without changing the argument is that the help file is a bit less descriptive. Not sure how I could change argparse to make this better.

Old:
```
 -l {modules,themes}, --list {modules,themes}
                        Display a list of either available themes or available
                        modules along with their parameters.
```
New:

```
 -l LIST [LIST ...], --list LIST [LIST ...]
                        Display a list of either available themes or available
                        modules along with their parameters.
```