### PR TITLE
layout-xkbswitch module

### DIFF
--- a/bumblebee/modules/layout-xkbswitch.py
+++ b/bumblebee/modules/layout-xkbswitch.py
@@ -1,0 +1,40 @@
+"""Displays and changes the current keyboard layout
+
+Requires the following executable:
+    * xkb-switch
+"""
+
+import bumblebee.util
+import bumblebee.input
+import bumblebee.output
+import bumblebee.engine
+
+
+class Module(bumblebee.engine.Module):
+    def __init__(self, engine, config):
+        widget = bumblebee.output.Widget(full_text=self.current_layout)
+        super(Module, self).__init__(engine, config, widget)
+        engine.input.register_callback(
+            self,
+            button=bumblebee.input.LEFT_MOUSE,
+            cmd=self._next_keymap)
+        self._current_layout = self._get_current_layout()
+
+    def current_layout(self, __):
+        return self._current_layout
+
+    def _next_keymap(self, event):
+        try:
+            bumblebee.util.execute("xkb-switch -n")
+        except RuntimeError:
+            pass
+
+    def _get_current_layout(self):
+        try:
+            res = bumblebee.util.execute("xkb-switch")
+            return res.split("\n")[0]
+        except RuntimeError:
+            return ["n/a"]
+
+    def update(self, __):
+        self._current_layout = self._get_current_layout()

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -20,6 +20,7 @@
   "load": { "prefix": "" },
   "layout": { "prefix": "" },
   "layout-xkb": { "prefix": "" },
+  "layout-xkbswitch": { "prefix": "" },
   "notmuch_count": {
     "empty": { "prefix": "\uf0e0" },
     "items": { "prefix": "\uf0e0" }


### PR DESCRIPTION
Another layout module that relies on xkb-switch (https://github.com/ierton/xkb-switch).

Shortest size with pretty much same functionality, because it doesn't have any heavy output parsing: xkb-switch is very laconic.