### PR TITLE
bumblebee.util.bytefmt() refactor

### DIFF
--- a/bumblebee/util.py
+++ b/bumblebee/util.py
@@ -46,6 +46,16 @@ def execute(cmd, wait=True):
     return rv
 
 def bytefmt(num):
+    """
+        format a value of bytes to a more human readable pattern
+        example: 15 * 1024 becomes 15KiB
+
+        Args:
+
+            num (int): bytes
+
+        Return: string
+    """
     for unit in ["", "Ki", "Mi", "Gi"]:
         if num < 1024.0:
             return "{:.2f}{}B".format(num, unit)

--- a/bumblebee/util.py
+++ b/bumblebee/util.py
@@ -45,7 +45,7 @@ def execute(cmd, wait=True):
     logging.info(u"command returned '{}'".format("" if not rv else rv))
     return rv
 
-def bytefmt(num):
+def bytefmt(num, fmt="{:.2f}"):
     """
         format a value of bytes to a more human readable pattern
         example: 15 * 1024 becomes 15KiB
@@ -54,13 +54,15 @@ def bytefmt(num):
 
             num (int): bytes
 
+            fmt (string): format
+
         Return: string
     """
     for unit in ["", "Ki", "Mi", "Gi"]:
         if num < 1024.0:
-            return "{:.2f}{}B".format(num, unit)
+            return "{}{}B".format(fmt, unit).format(num)
         num /= 1024.0
-    return "{:.2f}GiB".format(num*1024.0)
+    return "{}GiB".format(fmt).format(num*1024.0)
 
 def durationfmt(duration, shorten=False, suffix=False):
     duration = int(duration)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,6 +24,13 @@ class TestUtil(unittest.TestCase):
         self.assertEquals(bu.bytefmt(22 * 1024 * 1024 * 1024), "22.00GiB")
         self.assertEquals(bu.bytefmt(35 * 1024 * 1024 * 1024 * 1024), "35840.00GiB")
 
+        fmt = "{:.0f}"
+        self.assertEquals(bu.bytefmt(10, fmt), "10B")
+        self.assertEquals(bu.bytefmt(15 * 1024, fmt), "15KiB")
+        self.assertEquals(bu.bytefmt(20 * 1024 * 1024, fmt), "20MiB")
+        self.assertEquals(bu.bytefmt(22 * 1024 * 1024 * 1024, fmt), "22GiB")
+        self.assertEquals(bu.bytefmt(35 * 1024 * 1024 * 1024 * 1024, fmt), "35840GiB")
+
     def test_durationfmt(self):
         self.assertEquals(bu.durationfmt(00), "00:00")
         self.assertEquals(bu.durationfmt(25), "00:25")


### PR DESCRIPTION
I am planning to add a format parameter to **traffic** module, but it uses **bumblebee.util.bytefmt()**, which hardcodes the format. So I've refactored that function and added a format argument. It has a default value equal to the hardcoded one, so it should be backwards compatible.