### PR TITLE
Iconmarkup

### DIFF
--- a/bumblebee/config.py
+++ b/bumblebee/config.py
@@ -17,6 +17,7 @@ THEME_HELP = "Specify the theme to use for drawing modules"
 PARAMETER_HELP = "Provide configuration parameters in the form of <module>.<key>=<value>"
 LIST_HELP = "Display a list of either available themes or available modules along with their parameters."
 DEBUG_HELP = "Enable debug log, This will create '~/bumblebee-status-debug.log' by default, can be changed with the '-f' option"
+ICONMARKUP_HELP = "A Python format string that is valid Pango markup used for low level customization of icons on top of themes. There is no validation performed, this is delegated to the user. Used together with --markup=pango. Example: \"<span foreground='#ffffff' background='#000000'>{}</span>\". WARNING: highly experimental feature"
 
 class print_usage(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
@@ -61,6 +62,7 @@ def create_parser():
         help=MODULE_HELP)
     parser.add_argument("-t", "--theme", default="default", help=THEME_HELP)
     parser.add_argument("--markup", default="none", help="Specify the markup type of the output (e.g. 'pango')")
+    parser.add_argument("--iconmarkup", default="none", help=ICONMARKUP_HELP)
     parser.add_argument("-p", "--parameters", nargs="+", action='append', default=[],
         help=PARAMETER_HELP)
     parser.add_argument("-l", "--list", choices=["modules", "themes"], action=print_usage,
@@ -128,5 +130,8 @@ class Config(bumblebee.store.Store):
 
     def markup(self):
         return self._args.markup
+
+    def iconmarkup(self):
+        return self._args.iconmarkup
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -354,11 +354,11 @@ class WidgetDrawer(object):
         """add custom theme colors for prefix"""
         if self._markup == "pango":
             # add prefix/suffix colors
-            fg = self._theme.prefix_fg(widget)
-            bg = self._theme.prefix_bg(widget)
+            prefix_fg = self._theme.prefix_fg(widget)
+            prefix_bg = self._theme.prefix_bg(widget)
             self._prefix = "<span {} {}>{}</span>".format(
-                "foreground='{}'".format(fg) if fg else "",
-                "background='{}'".format(bg) if bg else "",
+                "foreground='{}'".format(prefix_fg) if prefix_fg else "",
+                "background='{}'".format(prefix_bg) if prefix_bg else "",
                 self._prefix
             )
 

--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -337,6 +337,8 @@ class WidgetDrawer(object):
         self._markup = None
         self._full_text = None
         self._prefix = None
+        self._prefix_fg = None
+        self._prefix_bg = None
         self._suffix = None
 
     def add_separator(self, widget, separator):
@@ -354,11 +356,11 @@ class WidgetDrawer(object):
         """add custom theme colors for prefix"""
         if self._markup == "pango":
             # add prefix/suffix colors
-            prefix_fg = self._theme.prefix_fg(widget)
-            prefix_bg = self._theme.prefix_bg(widget)
+            self._prefix_fg = self._theme.prefix_fg(widget)
+            self._prefix_bg = self._theme.prefix_bg(widget)
             self._prefix = "<span {} {}>{}</span>".format(
-                "foreground='{}'".format(prefix_fg) if prefix_fg else "",
-                "background='{}'".format(prefix_bg) if prefix_bg else "",
+                "foreground='{}'".format(self._prefix_fg) if self._prefix_fg else "",
+                "background='{}'".format(self._prefix_bg) if self._prefix_bg else "",
                 self._prefix
             )
 

--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -6,6 +6,7 @@ import sys
 import json
 import uuid
 import logging
+import xml.etree.ElementTree
 
 import bumblebee.store
 import bumblebee.util
@@ -339,6 +340,7 @@ class WidgetDrawer(object):
         self._prefix = None
         self._prefix_fg = None
         self._prefix_bg = None
+        self._iconmarkup = None
         self._suffix = None
 
     def add_separator(self, widget, separator):
@@ -351,6 +353,19 @@ class WidgetDrawer(object):
                 "background": self._theme.separator_bg(widget),
                 "separator_block_width": self._theme.separator_block_width(widget),
             })
+
+    def add_prefix_iconmarkup(self, widget):
+        """add custom Pango markup for prefix"""
+        element = xml.etree.ElementTree.XML(self._iconmarkup)
+        # if the custom markup has neither 'foreground' or 'fgcolor'
+        # attributes, but theme has prefixfg, merge it
+        if 'foreground' not in element.keys() and 'fgcolor' not in element.keys() and self._prefix_fg is not None:
+            element.set("foreground", self._prefix_fg)
+        # if the custom markup has neither 'background' or 'bgcolor'
+        # attributes, but theme has prefixbg, merge it
+        if 'background' not in element.keys() and 'bgcolor' not in element.keys() and self._prefix_bg is not None:
+            element.set("background", self._prefix_bg)
+        self._prefix = xml.etree.ElementTree.tostring(element).decode("utf-8").format(self._prefix)
 
     def add_prefix_colors(self, widget):
         """add custom theme colors for prefix"""
@@ -368,14 +383,26 @@ class WidgetDrawer(object):
             # add prefix/suffix colors
             self._prefix_fg = self._theme.prefix_fg(widget)
             self._prefix_bg = self._theme.prefix_bg(widget)
-            self.add_prefix_colors(widget)
+            self._iconmarkup = self._config.iconmarkup()
+            if self._iconmarkup != "none":
+                self.add_prefix_iconmarkup(widget)
+            else:
+                self.add_prefix_colors(widget)
 
         if self._prefix:
             self._full_text = u"{}{}".format(self._prefix, self._full_text)
 
+    def add_suffix_iconmarkup(self, widget):
+        """add custom Pango markup for suffix"""
+        self._suffix = self._iconmarkup.format(self._suffix)
+
     def add_suffix(self, widget, padding):
         """add suffix to full_text"""
         self._suffix = self._theme.suffix(widget, padding)
+
+        if self._markup == "pango":
+            if self._iconmarkup != "none":
+                self.add_suffix_iconmarkup(widget)
 
         if self._suffix:
             self._full_text = u"{}{}".format(self._full_text, self._suffix)

--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -354,21 +354,21 @@ class WidgetDrawer(object):
 
     def add_prefix_colors(self, widget):
         """add custom theme colors for prefix"""
-        if self._markup == "pango":
-            # add prefix/suffix colors
-            self._prefix_fg = self._theme.prefix_fg(widget)
-            self._prefix_bg = self._theme.prefix_bg(widget)
-            self._prefix = "<span {} {}>{}</span>".format(
-                "foreground='{}'".format(self._prefix_fg) if self._prefix_fg else "",
-                "background='{}'".format(self._prefix_bg) if self._prefix_bg else "",
-                self._prefix
-            )
+        self._prefix = "<span {} {}>{}</span>".format(
+            "foreground='{}'".format(self._prefix_fg) if self._prefix_fg else "",
+            "background='{}'".format(self._prefix_bg) if self._prefix_bg else "",
+            self._prefix
+        )
 
     def add_prefix(self, widget, padding):
         """add prefix to full_text"""
         self._prefix = self._theme.prefix(widget, padding)
 
-        self.add_prefix_colors(widget)
+        if self._markup == "pango":
+            # add prefix/suffix colors
+            self._prefix_fg = self._theme.prefix_fg(widget)
+            self._prefix_bg = self._theme.prefix_bg(widget)
+            self.add_prefix_colors(widget)
 
         if self._prefix:
             self._full_text = u"{}{}".format(self._prefix, self._full_text)


### PR DESCRIPTION
Implementation of low level access to Pango markup discussed here https://github.com/tobi-wan-kenobi/bumblebee-status/issues/531#issuecomment-578405381

For

    font pango:Iosevka 9

in i3 config, this is how mpd module looks by default:

![default](https://user-images.githubusercontent.com/40846997/74362597-e0df1f80-4dc0-11ea-9094-cd766b7af271.png)

and this is how it looks with

    --iconmarkup="<span font_desc='Iosevka 15' rise='-3500'>{}</span>"

![iconmarkup](https://user-images.githubusercontent.com/40846997/74362605-e8062d80-4dc0-11ea-96c9-088db599cb0e.png)

I am quite pleased with the visual result.