### PR TITLE
Remove print statement when aligning text

### DIFF
--- a/bumblebee/output.py
+++ b/bumblebee/output.py
@@ -74,7 +74,6 @@ def scrollable(func):
         if len(text) <= width:
             # do alignment
             align = module.parameter("theme.align", "left")
-            print("alignment: {}".format(align))
             if align == "right":
                 text = "{:>{}}".format(text, width)
             if align == "center":


### PR DESCRIPTION
Fixes #550. The print statement results in a "Could not parse JSON" error.