### PR TITLE
import popup_v2

### DIFF
--- a/bumblebee/modules/vpn.py
+++ b/bumblebee/modules/vpn.py
@@ -18,6 +18,7 @@ import logging
 import bumblebee.input
 import bumblebee.output
 import bumblebee.engine
+import bumblebee.popup_v2
 import functools
 
 class Module(bumblebee.engine.Module):


### PR DESCRIPTION
The vpn module is using bumblebee.popup_v2, but does not import it, causing nothing on click.