### PR TITLE
Properly connect to the selected VPN profile

### DIFF
--- a/bumblebee/modules/vpn.py
+++ b/bumblebee/modules/vpn.py
@@ -76,7 +76,7 @@ class Module(bumblebee.engine.Module):
 
         try:
             bumblebee.util.execute("nmcli c up \"{vpn}\""
-                                   .format(vpn=self._connected_vpn_profile))
+                                   .format(vpn=self._selected_vpn_profile))
             self._connected_vpn_profile = name
         except Exception as e:
             logging.exception("Couldn't establish VPN connection")


### PR DESCRIPTION
The vpn module is trying to connect "self._connected_vpn_profile", but it is None when no VPN is connected. As a result, the VPN connecting menu is not working. Use "self._selected_vpn_profile" to connect the selected one.