### PR TITLE
[modules/cpu2] align cpu load

### DIFF
--- a/bumblebee/modules/cpu2.py
+++ b/bumblebee/modules/cpu2.py
@@ -89,7 +89,7 @@ class Module(bumblebee.engine.Module):
         return "{:.2f}GHz".format(self._maxfreq)
 
     def cpuload(self, _):
-        return "{}%".format(self._cpuload)
+        return "{:>3}%".format(self._cpuload)
 
     def add_color(self, bar):
         """add color as pango markup to a bar"""


### PR DESCRIPTION
This fixes a rough edge in cpu2 module where variable size of total cpu
load value string was making the whole bar slide during updates. CPU
load is right-aligned now and takes 3 chars in the widget, so load can
go up to 100 and still fit.