### PR TITLE
[modules/pomodoro] Fix bug arising when the refresh interval is greater than 1s

### DIFF
--- a/bumblebee/modules/pomodoro.py
+++ b/bumblebee/modules/pomodoro.py
@@ -80,7 +80,7 @@ class Module(bumblebee.engine.Module):
                 self.remaining_time -= timediff
                 self.time = datetime.datetime.now()
 
-            if self.remaining_time.seconds <= 0:
+            if self.remaining_time.total_seconds() <= 0:
                 self.notify()
                 if self.pomodoro["type"] == "Work":
                     self.pomodoro["type"] = "Break"


### PR DESCRIPTION
The bug is that the `seconds` attribute of a `timedelta` is never negative. This becomes a problem when subtracting 5 seconds to a `remaining_time` of 3 seconds because Python represents a negative time delta using a negative number of days while keeping the number of seconds positive. [0]

The fix uses `total_seconds()` to get the expected behavior, and the function is available for Python 2.7+ [1] and 3.2+ [2].

To test the problem and its fix, you can use this line in your i3 config: `status_command ~/.local/bin/bumblebee-status -m pomodoro -p interval=5 pomodoro.work="1"` (left click to start a pomodoro and wait 1 min for the counter to go down)

[0] You can create such object with `datetime.timedelta(seconds=-1)`
[1] https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds
[2] https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds