### PR TITLE
Fixing no internet crash (Sun Module)

### DIFF
--- a/bumblebee/modules/sun.py
+++ b/bumblebee/modules/sun.py
@@ -64,6 +64,8 @@ class Module(bumblebee.engine.Module):
     def _calculate_times(self):
         self._isup = False
         try:
+            if not self._lat or not self._lon:
+                raise()
             sun = Sun(self._lat, self._lon)
         except Exception:
             self._sunrise = None


### PR DESCRIPTION
![error](https://user-images.githubusercontent.com/6232650/78472476-c3d02880-7741-11ea-9b7a-feba03c69776.png)
Using sun module without internet crashes the status bar. With this patch instead of crashing it will show a question mark.
![second](https://user-images.githubusercontent.com/6232650/78472517-1e698480-7742-11ea-88ab-b8621a400e95.png)
