### PR TITLE
[modules/vpn] fixed typo in vpn module

### DIFF
--- a/modules/contrib/vpn.py
+++ b/modules/contrib/vpn.py
@@ -71,7 +71,7 @@ class Module(core.module.Module):
 
     def __on_vpndisconnect(self):
         try:
-            util.lci.execute('nmcli c down \'{vpn}\''
+            util.cli.execute('nmcli c down \'{vpn}\''
                                    .format(vpn=self.__connected_vpn_profile))
             self.__connected_vpn_profile = None
         except Exception as e:


### PR DESCRIPTION
* due to a typo in the vpn module it wasn't possible anymore to
disconnect an established vpn connection.