### PR TITLE
[WIP] Fix scrolling decorator out of bounds scrolling

### DIFF
--- a/core/decorators.py
+++ b/core/decorators.py
@@ -41,21 +41,23 @@ def scrollable(func):
         direction = widget.get("scrolling.direction", "right")
 
         if direction == "left":
-            scroll_speed = -scroll_speed
-            if start + scroll_speed <= 0:  # bounce back
+            if start - scroll_speed <= 0:  # bounce back
                 widget.set("scrolling.direction", "right")
+            else:
+                scroll_speed *= -1
+        else:
+            if start + scroll_speed + width > len(text):
+                if not bounce:
+                    start = -scroll_speed
+                else:
+                    start = len(text) - width
+                    scroll_speed *= -1
+                    widget.set("scrolling.direction", "left")
 
         next_start = start + scroll_speed
-        if next_start + width > len(text):
-            if not bounce:
-                next_start = 0
-            else:
-                next_start = start - scroll_speed
-                widget.set("scrolling.direction", "left")
-
         widget.set("scrolling.start", next_start)
 
-        return text[start : start + width]
+        return text[start:start + width]
 
     return wrapper
 


### PR DESCRIPTION
I discovered this while using the cmus module.

When a song was playing that had a long name and the next one was shorter, but still too long to fit in the max_width space and at the exact moment when the song changes, the previous one is scrolled farther than the next one will be at most, it starts to clip the string one by one character until nothing is left.

Here's what the output looks like:

https://pastebin.com/JKa67jd1

I'll try to explain it on a imaginary example:

Say the max_width is 5 and a song is playing that is 15 characters long in the output. At some point while scrolling the output will look like this. The `[]` indicate the part that is actually returned.

```
AAAAAAAAAA[AAAAA]
           ^
```

The next song is say 12 characters long. The start index is preserved between songs, as it is saved on the widget, so the output looks like this:

```
AAAAAAAAAA[AA]
           ^
```

Here something weird happens that I haven't been able to hunt down exactly what, but the output gets truncated character by character in each iteration (look at the pastebin output). My solution is to just move the start index to the last character that will still show the full width of the sliding window and continue scrolling left normally. So instead of the above, something like this:

```
AAAAAAA[AAAAA]
        ^
```

That way the text isn't cut off when switching to shorter songs after long ones.

Another issue was when the text was 1 character longer than the window. In that case it would cycle between 3 states - right, left and -1. That should be fixed no too.

I have tested it a bit and so far haven't found any issue with it, but only with the cmus module, so it would probably be smart to test the other scrollable ones as well.