### PR TITLE
Handle n+1 characters in the scrolling decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ ENV/
 
 # Visual studio project files
 .vscode/
+
+# mypy cache
+.mypy_cache

--- a/bumblebee_status/core/decorators.py
+++ b/bumblebee_status/core/decorators.py
@@ -1,5 +1,9 @@
 import difflib
+import logging
+
 import util.format
+
+log = logging.getLogger(__name__)
 
 
 def never(init):
@@ -49,9 +53,10 @@ def scrollable(func):
         direction = widget.get("scrolling.direction", "right")
 
         if direction == "left":
-            scroll_speed = -scroll_speed
-            if start + scroll_speed <= 0:  # bounce back
+            if start - scroll_speed < 0:  # bounce back
                 widget.set("scrolling.direction", "right")
+            else:
+                scroll_speed = -scroll_speed
 
         next_start = start + scroll_speed
         if next_start + width > len(text):

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -81,5 +81,14 @@ class config(unittest.TestCase):
         self.module.text = "this is a different song (0:12)"
         self.assertEqual(self.module.text[0:10], self.module.get(self.widget))
 
+    def test_n_plus_one(self):
+        self.module.text = "10 letters"
+        self.module.set("scrolling.width", 9)
+        self.assertEqual(self.module.text[0:9], self.module.get(self.widget))
+        self.assertEqual(self.module.text[1:10], self.module.get(self.widget))
+        self.assertEqual(self.module.text[0:9], self.module.get(self.widget))
+        self.assertEqual(self.module.text[1:10], self.module.get(self.widget))
+        self.assertEqual(self.module.text[0:9], self.module.get(self.widget))
+
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Hopefully the last fix for cmus :smile: 

When the text is 1 character longer than the width of the module it scrolls once to the right, once to the left and then to -1 ending up with an empty string in the output. Then returns back to 0 and starts over again.

I wrote a test, found the edge case, and hopefully fixed it with this.

PS. I also added `.mypy_cache` to the gitignore file. It's a static type checking tool that keeps its cache in the repo. I recommend it for type annotated code checking.