### PR TITLE
Fix network_traffic mobule on development

### DIFF
--- a/bumblebee_status/modules/contrib/network_traffic.py
+++ b/bumblebee_status/modules/contrib/network_traffic.py
@@ -17,6 +17,7 @@ import util.format
 
 WIDGET_NAME = "network_traffic"
 
+
 class Module(core.module.Module):
     def __init__(self, config, theme):
         widgets = [

--- a/bumblebee_status/modules/contrib/network_traffic.py
+++ b/bumblebee_status/modules/contrib/network_traffic.py
@@ -17,22 +17,22 @@ import util.format
 
 WIDGET_NAME = "network_traffic"
 
-
 class Module(core.module.Module):
     def __init__(self, config, theme):
         widgets = [
             core.widget.Widget(
-                module=self,
                 name="{0}.rx".format(WIDGET_NAME),
                 full_text=self.download_rate,
             ),
             core.widget.Widget(
-                module=self,
                 name="{0}.tx".format(WIDGET_NAME),
                 full_text=self.upload_rate,
             ),
         ]
         super().__init__(config, theme, widgets)
+
+        self.widgets()[0].module = self
+        self.widgets()[1].module = self
 
         self.widgets()[0].set("theme.minwidth", "0000000KiB/s")
         self.widgets()[1].set("theme.minwidth", "0000000KiB/s")


### PR DESCRIPTION
When I shifted over to the development branch after reading some of the recent activity on github, I found a problem with the `network_traffic` module.  Here is a simple PR that fixes this immediately problem but there is a bigger issue with `development:core.widget.Widget`.  Namely, if a module uses the `module=` arg in the `__init__` then it is going to crash because there is some sort of a circular reference in the `index()` call needed for setting the `widgets` parameter. 

I have only look at your code for a half-hour, so I do cannot talk in more detail.  I'd be happy to look at it more if needed.  It seems that no other modules use the `module=` arg to `__init__`...

Thanks for a great tool.