### PR TITLE
fix a regression for shell subprocess

### DIFF
--- a/bumblebee_status/modules/contrib/shell.py
+++ b/bumblebee_status/modules/contrib/shell.py
@@ -60,7 +60,7 @@ class Module(core.module.Module):
     def update(self):
         # if requested then run not async version and just execute command in this thread
         if not self.__async:
-            self.__output = util.cli.execute(self.__command, ignore_errors=True).strip()
+            self.__output = util.cli.execute(self.__command, shell=True, ignore_errors=True).strip()
             return
 
         # if previous thread didn't end yet then don't do anything


### PR DESCRIPTION
Hello,

I was using the `shell` module to run a command which used a subshell. 

Unfortunately after the last update to `bumblebee-status` this stopped working. The `$(...)` in my command was interpreted literally instead of spawning a subshell. 

Putting `shell=True` in the call to `util.cli.execute` in `shell.py` fixed the problem for me. 

I see on SO that there may be security concerns related to shell injection when using `shell=True` so perhaps there is a better way to fix my problem? I'm not too sure.

Thanks,
Elliott.