### PR TITLE
Do not execute iwgetid if the interface is recognized as tunnel

### DIFF
--- a/bumblebee_status/modules/core/nic.py
+++ b/bumblebee_status/modules/core/nic.py
@@ -125,7 +125,7 @@ class Module(core.module.Module):
             widget.set("state", state)
 
     def get_ssid(self, intf):
-        if self._iswlan(intf) and self.iwgetid:
+        if self._iswlan(intf) and not self._istunnel(intf) and self.iwgetid:
             return util.cli.execute(
                 "{} -r {}".format(self.iwgetid, intf), ignore_errors=True
             )


### PR DESCRIPTION
Fixes #659

`iwgetid` is used to gather the SSID of a wireless network interface. However due to the fact that some interfaces may start with a `w` that no wireless interfaces, we should execute `iwgetid` only if the interface is not recognized as tunnel as well. 