### PR TITLE
Convert spotify.pause to an action

### DIFF
--- a/bumblebee_status/modules/contrib/spotify.py
+++ b/bumblebee_status/modules/contrib/spotify.py
@@ -89,9 +89,9 @@ class Module(core.module.Module):
                         ).Get("org.mpris.MediaPlayer2.Player", "PlaybackStatus")
                     )
                     if playback_status == "Playing":
-                        widget.set("state", "playing")
-                    else:
                         widget.set("state", "paused")
+                    else:
+                        widget.set("state", "playing")
                 elif widget_name == "spotify.next":
                     widget_map[widget] = {
                         "button": core.input.LEFT_MOUSE,


### PR DESCRIPTION
This is probably controversial and bike-shedding at its best, so feel free to ignore.

In the recent weeks, widget buttons have replaced mouse actions in the `spotify` module. However, I feel the logic for the play/pause button is confusing. The buttons `next`, `prev` are currently actions, however the button `play`/`pause` is reflecting a state, i.e. when playing a `playìng` triangle is displayed and also when paused a `paused` double-line. If implemented as an action instead like the other buttons ("please pause", "please play"), the widget icons would be the exact opposite: a triangle when paused and double-line when playing and indeed this is exactly the pattern every other player (and especially Spotify itself) implements.

This PR switches the icons to reflect a desired action instead of state.