### PR TITLE
Fix wrong usage of asbool in layout-xkb

### DIFF
--- a/bumblebee_status/modules/core/layout-xkb.py
+++ b/bumblebee_status/modules/core/layout-xkb.py
@@ -53,7 +53,7 @@ class Module(core.module.Module):
             log.debug("group num: {}".format(xkb.group_num))
             name = (
                 xkb.group_name
-                if util.format.asbool(self.parameter("showname"), False)
+                if util.format.asbool(self.parameter("showname", False))
                 else xkb.group_symbol
             )
             if self.__show_variant:


### PR DESCRIPTION
In Line 56 the `util.format.asbool` method was used with 2 instead of 1 parameter due to a misplaced `)`.
This caused the module to fail and therefore the json passed to i3 was malformed.