### PR TITLE
Force status bar to update early using USR1 signal

### DIFF
--- a/bumblebee-status
+++ b/bumblebee-status
@@ -4,6 +4,7 @@ import os
 import sys
 import json
 import time
+import signal
 import socket
 import select
 import logging
@@ -103,6 +104,12 @@ def main():
     input_thread.daemon = True
     input_thread.start()
 
+    def sig_USR1_handler(signum,stack):
+        if update_lock.acquire(blocking=False) == True:
+            core.event.trigger("update", redraw_only=False)
+            core.event.trigger("draw")
+            update_lock.release()
+
     if config.debug():
         modules.append(core.module.load("debug", config, theme))
 
@@ -120,6 +127,7 @@ def main():
 
     core.event.trigger("start")
     started = True
+    signal.signal(10, sig_USR1_handler)
     while True:
         if update_lock.acquire(blocking=False) == True:
             core.event.trigger("update")

--- a/bumblebee_status/core/output.py
+++ b/bumblebee_status/core/output.py
@@ -222,13 +222,14 @@ class i3(object):
         return blocks
 
     # TODO: only updates full text, not the state!?
+    # can this TODO be removed now? Will update the state if not redraw_only
     def update(self, affected_modules=None, redraw_only=False):
         now = time.time()
         for module in self.__modules:
             if affected_modules and not module.id in affected_modules:
                 continue
             if not affected_modules and module.next_update:
-                if now < module.next_update:
+                if now < module.next_update and redraw_only:
                     continue
 
             if not redraw_only:


### PR DESCRIPTION
This is something I added a [few years ago](https://github.com/tobi-wan-kenobi/bumblebee-status/pull/255) that seems to have been lost over the years. Everything seems to have changed a lot since then, but this PR reintroduces this functionality as it is something that has always been very useful to me and may continue to be useful to others.

I've no idea whether this functionality was removed intentionally; if that is the case, I understand rejecting this PR. 

If there is anything that needs tweaking (perhaps I've committed some unthinkable crime against bumblebee), point me in the right direction and I will fix it as soon as I can.