### PR TITLE
Quotes around the deadbeef string to prevent parsing errors by deadbeef

### DIFF
--- a/bumblebee_status/modules/contrib/deadbeef.py
+++ b/bumblebee_status/modules/contrib/deadbeef.py
@@ -114,7 +114,7 @@ class Module(core.module.Module):
             self._song = ""
             return
         ## perform the actual query -- these can be much more sophisticated
-        data = util.cli.execute(self.now_playing_tf + self._tf_format)
+        data = util.cli.execute(self.now_playing_tf + '"'+self._tf_format+'"')
         self._song = data
 
     def update_standard(self, widgets):


### PR DESCRIPTION
If using complex queries, deadbeef can fail to parse the query properly if it is not surrounded by quotes. This PR surrounds the query with quotes to mitigate against this.