### PR TITLE
[github]: Remove error print on exception catch

### DIFF
--- a/bumblebee_status/modules/contrib/github.py
+++ b/bumblebee_status/modules/contrib/github.py
@@ -83,7 +83,6 @@ class Module(core.module.Module):
                 self.__label += "/".join(counts)
 
         except Exception as err:
-            print(err)
             self.__label = "n/a"
 
     def __getUnreadNotificationsCountByReason(self, notifications, reason):


### PR DESCRIPTION
I experienced that when an exception is caught and we print it I get an ugly error on the whole bar making it unusable. This
fixes that problem.

![2020-08-15_17-33](https://user-images.githubusercontent.com/972572/90778217-bec7dc00-e2d2-11ea-9f6d-98f116b6648c.png)
