### PR TITLE
Add Network Traffic module tests

### DIFF
--- a/bumblebee_status/modules/contrib/network_traffic.py
+++ b/bumblebee_status/modules/contrib/network_traffic.py
@@ -38,8 +38,8 @@ class Module(core.module.Module):
         try:
             self._bandwidth = BandwidthInfo()
 
-            self._rate_recv = "?"
-            self._rate_sent = "?"
+            self._rate_recv = 0
+            self._rate_sent = 0
             self._bytes_recv = self._bandwidth.bytes_recv()
             self._bytes_sent = self._bandwidth.bytes_sent()
         except Exception:

--- a/tests/modules/contrib/test_network_traffic.py
+++ b/tests/modules/contrib/test_network_traffic.py
@@ -1,9 +1,57 @@
 import pytest
+from unittest import TestCase, mock
+
+import core.config
+import core.widget
+import modules.contrib.network_traffic
+
+from types import SimpleNamespace
 
 pytest.importorskip("psutil")
-
 pytest.importorskip("netifaces")
 
-def test_load_module():
-    __import__("modules.contrib.network_traffic")
+def io_counters_mock(recv, sent):
+    return {
+        'lo': SimpleNamespace(
+            bytes_sent = sent,
+            bytes_recv = recv
+        )
+    }
+
+def gateways_response():
+    return {
+        'default': {
+            1: ('10.0.0.10', 'lo')
+        }
+    }
+
+def build_module():
+    return modules.contrib.network_traffic.Module(config=core.config.Config([]), theme=None)
+
+class TestNetworkTrafficUnit(TestCase):
+    def test_load_module(self):
+        __import__("modules.contrib.network_traffic")
+
+    @mock.patch('psutil.net_io_counters')
+    @mock.patch('netifaces.gateways')
+    @mock.patch('netifaces.AF_INET', 1)
+    def test_update_rates(self, gateways_mock, net_io_counters_mock):
+        net_io_counters_mock.return_value = io_counters_mock(0, 0)
+        gateways_mock.return_value = gateways_response()
+
+        module = build_module()
+
+        net_io_counters_mock.return_value = io_counters_mock(2842135, 1932215)
+        module.update()
+
+        assert module.widgets()[1].full_text() == '1.84MiB/s'
+        assert module.widgets()[0].full_text() == '2.71MiB/s'
+
+    def test_initial_download_rate(self):
+        module = build_module()
+        assert module.widgets()[0].full_text() == '0.00B/s'
+
+    def test_initial_upload_rate(self):
+        module = build_module()
+        assert module.widgets()[1].full_text() == '0.00B/s'
 


### PR DESCRIPTION
Hey there.

In this PR we create some ~basic~ tests to `network_traffic` module. :tada: 

I tried to cover only the `Widget.full_text` and `Module.update` methods. I believe these are the only methods that the core module uses for the main behavior.

I'm accepting suggestions! :relaxed: 

Related issue: #641.
