### PR TITLE
Fix memory module tests

### DIFF
--- a/bumblebee_status/modules/core/memory.py
+++ b/bumblebee_status/modules/core/memory.py
@@ -41,18 +41,8 @@ class Module(core.module.Module):
         return self._format.format(**self._mem)
 
     def update(self):
-        data = {}
-        with open("/proc/meminfo", "r") as f:
-            for line in f:
-                tmp = re.split(r"[:\s]+", line)
-                value = int(tmp[1])
-                if tmp[2] == "kB":
-                    value = value * 1024
-                if tmp[2] == "mB":
-                    value = value * 1024 * 1024
-                if tmp[2] == "gB":
-                    value = value * 1024 * 1024 * 1024
-                data[tmp[0]] = value
+        data = self.__parse_meminfo()
+
         if "MemAvailable" in data:
             used = data["MemTotal"] - data["MemAvailable"]
         else:
@@ -78,5 +68,26 @@ class Module(core.module.Module):
             return "warning"
         return None
 
+    def __parse_meminfo(self):
+        data = {}
+        with open("/proc/meminfo", "r") as f:
+            # https://bugs.python.org/issue32933
+            while True:
+                line = f.readline()
+
+                if line == '':
+                    break
+
+                tmp = re.split(r"[:\s]+", line)
+                value = int(tmp[1])
+                if tmp[2] == "kB":
+                    value = value * 1024
+                if tmp[2] == "mB":
+                    value = value * 1024 * 1024
+                if tmp[2] == "gB":
+                    value = value * 1024 * 1024 * 1024
+                data[tmp[0]] = value
+
+        return data
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/bumblebee_status/modules/core/memory.py
+++ b/bumblebee_status/modules/core/memory.py
@@ -72,12 +72,7 @@ class Module(core.module.Module):
         data = {}
         with open("/proc/meminfo", "r") as f:
             # https://bugs.python.org/issue32933
-            while True:
-                line = f.readline()
-
-                if line == '':
-                    break
-
+            for line in f.readlines():
                 tmp = re.split(r"[:\s]+", line)
                 value = int(tmp[1])
                 if tmp[2] == "kB":

--- a/bumblebee_status/modules/core/memory.py
+++ b/bumblebee_status/modules/core/memory.py
@@ -74,15 +74,22 @@ class Module(core.module.Module):
             # https://bugs.python.org/issue32933
             for line in f.readlines():
                 tmp = re.split(r"[:\s]+", line)
-                value = int(tmp[1])
-                if tmp[2] == "kB":
-                    value = value * 1024
-                if tmp[2] == "mB":
-                    value = value * 1024 * 1024
-                if tmp[2] == "gB":
-                    value = value * 1024 * 1024 * 1024
+                value = self.__parse_value(tmp)
+
                 data[tmp[0]] = value
 
         return data
+
+    def __parse_value(self, data):
+        value = int(data[1])
+
+        if data[2] == "kB":
+            value = value * 1024
+        if data[2] == "mB":
+            value = value * 1024 * 1024
+        if data[2] == "gB":
+            value = value * 1024 * 1024 * 1024
+
+        return value
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tests/modules/core/test_memory.py
+++ b/tests/modules/core/test_memory.py
@@ -15,6 +15,7 @@ def memory_widget(module):
 def meminfo_mock(
     total,
     available,
+    unit = 'kB',
     free = 0,
     buffers = 0,
     cached = 0,
@@ -31,7 +32,7 @@ def meminfo_mock(
     ]
 
     for i, (key, value) in enumerate(states):
-        data.append('{}: {} kB'.format(key, value))
+        data.append('{}: {} {}'.format(key, value, unit))
 
     return '\n'.join(data)
 
@@ -118,3 +119,25 @@ class TestMemory(TestCase):
 
         assert widget.full_text() == '50.0%'
         assert module.state(widget) == None
+
+
+    @mock.patch('builtins.open', mock.mock_open(read_data=meminfo_mock(8196, 4096, 'mB')))
+    def test_mb_unit(self):
+        module = build_module()
+        module.update()
+
+        widget = memory_widget(module)
+
+        assert widget.full_text() == '4.00GiB/8.00GiB (50.02%)'
+        assert module.state(widget) == None
+
+    @mock.patch('builtins.open', mock.mock_open(read_data=meminfo_mock(2, 1, 'gB')))
+    def test_gb_unit(self):
+        module = build_module()
+        module.update()
+
+        widget = memory_widget(module)
+
+        assert widget.full_text() == '1.00GiB/2.00GiB (50.00%)'
+        assert module.state(widget) == None
+

--- a/tests/modules/core/test_memory.py
+++ b/tests/modules/core/test_memory.py
@@ -30,7 +30,6 @@ def meminfo_mock(
         ('Slab', slab)
     ]
 
-
     for i, (key, value) in enumerate(states):
         data.append('{}: {} kB'.format(key, value))
 


### PR DESCRIPTION
Hey there.

In this PR we change the way `memory` module parses `/proc/meminfo`.

This is a known bug in older Python versions related to `mock_open`: https://bugs.python.org/issue32933

Related PR: #695 