### PR TITLE
Improve network traffic module tests

### DIFF
--- a/bumblebee_status/modules/contrib/network_traffic.py
+++ b/bumblebee_status/modules/contrib/network_traffic.py
@@ -97,9 +97,6 @@ class BandwidthInfo(object):
         """Return default active network adapter"""
         gateway = netifaces.gateways()["default"]
 
-        if not gateway:
-            raise "No default gateway found"
-
         return gateway[netifaces.AF_INET][1]
 
     @classmethod

--- a/tests/modules/contrib/test_network_traffic.py
+++ b/tests/modules/contrib/test_network_traffic.py
@@ -89,3 +89,15 @@ class TestNetworkTrafficUnit(TestCase):
 
         assert download_widget(module).full_text() == '30.00MiB/s'
         assert upload_widget(module).full_text() == '512.00KiB/s'
+
+    def test_widget_states(self):
+        module = build_module()
+
+        assert module.state(download_widget(module)) == 'rx'
+        assert module.state(upload_widget(module)) == 'tx'
+
+    def test_invalid_widget_state(self):
+        module = build_module()
+        invalid_widget = core.widget.Widget(name='invalid')
+
+        assert module.state(invalid_widget) == None


### PR DESCRIPTION
Hey there.

This PRs improves `network_traffic` module tests and remove useless `if` conditional from the module logic. :tada: 