### PR TITLE
[modules/dunstctl]: Toggle dunst v1.5.0+ notifications using dunstctl

### DIFF
--- a/bumblebee_status/modules/contrib/dunstctl.py
+++ b/bumblebee_status/modules/contrib/dunstctl.py
@@ -1,0 +1,42 @@
+# pylint: disable=C0111,R0903
+
+"""
+Toggle dunst notifications using dunstctl.
+
+When notifications are paused using this module dunst doesn't get killed and you'll keep getting notifications on the background that will be displayed when unpausing.
+This is specially useful if you're using dunst's scripting (https://wiki.archlinux.org/index.php/Dunst#Scripting), which requires dunst to be running. Scripts will be executed when dunst gets unpaused.
+
+Requires:
+    * dunst v1.5.0+
+
+contributed by `cristianmiranda <https://github.com/cristianmiranda>`_ - many thanks!
+"""
+
+import core.module
+import core.widget
+import core.input
+
+import util.cli
+
+
+class Module(core.module.Module):
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(""))
+        self._paused = self.__isPaused()
+        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.toggle_status)
+
+    def toggle_status(self, event):
+        self._paused = self.__isPaused()
+        if self._paused:
+            util.cli.execute("dunstctl set-paused false")
+        else:
+            util.cli.execute("dunstctl set-paused true")
+        self._paused = not self._paused
+
+    def __isPaused(self):
+        return util.cli.execute("dunstctl is-paused").strip() == "true"
+
+    def state(self, widget):
+        if self._paused:
+            return ["muted", "warning"]
+        return ["unmuted"]

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -257,6 +257,10 @@
     "muted": { "prefix": "" },
     "unmuted": { "prefix": "" }
   },
+  "dunstctl": {
+    "muted": { "prefix": "" },
+    "unmuted": { "prefix": "" }
+  },
   "twmn": {
     "muted": { "prefix": "" },
     "unmuted": { "prefix": "" }


### PR DESCRIPTION
The current `dunst` module kills dunst when toggled which prevents the daemon to execute scripts if configured. This new module is intended to be used only if you have the latest version of dunst (v1.5.0 or greater).

![2020-09-04_17-31](https://user-images.githubusercontent.com/972572/92282706-91834c80-eed4-11ea-9035-83fe14e4387d.png)
![2020-09-04_17-31_1](https://user-images.githubusercontent.com/972572/92282708-921be300-eed4-11ea-84b0-cb56a7bfafc8.png)

Have a great weekend! 😄 