### PR TITLE
Force feedparser to 6.0.0b1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install -U coverage==4.3 pytest pytest-mock freezegun
   - pip install codeclimate-test-reporter
   - pip install i3-py Pillow Babel DateTime python-dateutil
-  - pip install docker feedparser i3ipc
+  - pip install docker feedparser==6.0.0b1 i3ipc
   - pip install netifaces power
   - pip install psutil pytz
   - pip install requests simplejson

--- a/requirements/modules/rss.txt
+++ b/requirements/modules/rss.txt
@@ -1,1 +1,1 @@
-feedparser
+feedparser==6.0.0b1


### PR DESCRIPTION
Hey ya.

`feedparser` 6.0.0b2+ does not support Python 3.5- anymore.

This PR forces `feedparser` to `6.0.0b1` just to keep things running.

