### PR TITLE
Create symbolic links

### DIFF
--- a/bumblebee_status/modules/contrib/arch_update.py
+++ b/bumblebee_status/modules/contrib/arch_update.py
@@ -1,0 +1,1 @@
+arch-update.py

--- a/bumblebee_status/modules/contrib/battery_upower.py
+++ b/bumblebee_status/modules/contrib/battery_upower.py
@@ -1,0 +1,1 @@
+battery-upower.py

--- a/bumblebee_status/modules/contrib/layout_xkbswitch.py
+++ b/bumblebee_status/modules/contrib/layout_xkbswitch.py
@@ -1,0 +1,1 @@
+layout-xkbswitch.py

--- a/bumblebee_status/modules/core/layout_xkb.py
+++ b/bumblebee_status/modules/core/layout_xkb.py
@@ -1,0 +1,1 @@
+layout-xkb.py

--- a/docs/development/module.rst
+++ b/docs/development/module.rst
@@ -11,6 +11,7 @@ Adding a new module to ``bumblebee-status`` is straight-forward:
    ``bumblebee-status`` (i.e. a module called
    ``bumblebee_status/modules/contrib/test.py`` will be loaded using
    ``bumblebee-status -m test``)
+-  The module name must follow the `Python Naming Conventions <https://www.python.org/dev/peps/pep-0008/#package-and-module-names>`_
 -  See below for how to actually write the module
 -  Test (run ``bumblebee-status`` in the CLI)
 -  Make sure your changes don’t break anything: ``./coverage.sh``

--- a/tests/modules/contrib/test_arch-update.py
+++ b/tests/modules/contrib/test_arch-update.py
@@ -3,3 +3,5 @@ import pytest
 def test_load_module():
     __import__("modules.contrib.arch-update")
 
+def test_load_symbolic_link_module():
+    __import__("modules.contrib.arch_update")

--- a/tests/modules/contrib/test_battery-upower.py
+++ b/tests/modules/contrib/test_battery-upower.py
@@ -5,3 +5,6 @@ pytest.importorskip("dbus")
 def test_load_module():
     __import__("modules.contrib.battery-upower")
 
+def test_load_symbolic_link_module():
+    __import__("modules.contrib.battery_upower")
+

--- a/tests/modules/contrib/test_layout-xkbswitch.py
+++ b/tests/modules/contrib/test_layout-xkbswitch.py
@@ -3,3 +3,5 @@ import pytest
 def test_load_module():
     __import__("modules.contrib.layout-xkbswitch")
 
+def test_load_symbolic_link_module():
+    __import__("modules.contrib.layout_xkbswitch")

--- a/tests/modules/core/test_layout-xkb.py
+++ b/tests/modules/core/test_layout-xkb.py
@@ -5,3 +5,5 @@ pytest.importorskip("xkbgroup")
 def test_load_module():
     __import__("modules.core.layout-xkb")
 
+def test_load_symbolic_link_module():
+    __import__("modules.core.layout_xkb")


### PR DESCRIPTION
Hey!

This PR creates symbolic links to modules with hyphens to match the Python Naming Conventions.

As discussed, we would like to keep the current naming with hyphens as an option because of backwards compatibility.

Fixes #713