### PR TITLE
Add org-mode TODO module

### DIFF
--- a/bumblebee_status/modules/contrib/todo_org.py
+++ b/bumblebee_status/modules/contrib/todo_org.py
@@ -1,0 +1,57 @@
+# pylint: disable=C0111,R0903
+"""Displays the number of todo items from an org-mode file
+Parameters:
+    * todo_org.file:      File to read TODOs from (defaults to ~/org/todo.org)
+    * todo_org.remaining: False by default. When true, will output the number of remaining todos instead of the number completed (i.e. 1/4 means 1 of 4 todos remaining, rather than 1 of 4 todos completed)
+Based on the todo module by `codingo <https://github.com/codingo>`
+"""
+
+import re
+import os.path
+
+import core.module
+import core.widget
+import core.input
+from util.format import asbool
+
+class Module(core.module.Module):
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.output))
+
+        self.__todo_regex = re.compile("^\\s*\\*+\\s*TODO")
+        self.__done_regex = re.compile("^\\s*\\*+\\s*DONE")
+
+        self.__doc = os.path.expanduser(
+            self.parameter("file", "~/org/todo.org")
+        )
+        self.__remaining = asbool(self.parameter("remaining", "False"))
+        self.__todo, self.__total = self.count_items()
+        core.input.register(
+            self,
+            button=core.input.LEFT_MOUSE,
+            cmd="emacs {}".format(self.__doc)
+        )
+
+    def output(self, widget):
+        if self.__remaining:
+            return "TODO: {}/{}".format(self.__todo, self.__total)
+        return "TODO: {}/{}".format(self.__total-self.__todo, self.__total)
+
+    def update(self):
+        self.__todo, self.__total = self.count_items()
+
+    def count_items(self):
+        todo, total = 0, 0
+        try:
+            with open(self.__doc, "r") as f:
+                for line in f:
+                    if self.__todo_regex.match(line.upper()) is not None:
+                        todo += 1
+                        total += 1
+                    elif self.__done_regex.match(line.upper()) is not None:
+                        total += 1
+            return todo, total
+        except OSError:
+            return -1, -1
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This is based on the existing `todo.txt`-based module, but is modified to better suit the TODO system built into emacs's org-mode. Documents in org-mode can contain TODO lines as well as non-TODO lines, which this module will differentiate between, and org-mode marks completed items with DONE, which this module can also identify.

The module uses regular expressions to find valid TODO and DONE entries (it will ignore whitespace before the asterisks, allow any number of asterisks for deeply embedded TODOs, and will ignore whitespace between the asterisks and the TODO marker itself) and can display it as either (by default) the total number of TODOs completed out of the total number (i.e. 1/4 = 1 TODO completed out of 4) or the total number remaining (i.e. 1/4 = 1 TODO remaining out of 4).

Left clicking the module on the status bar will open the TODO file in emacs.