### PR TITLE
Create layout-xkbswitch tests

### DIFF
--- a/bumblebee_status/modules/contrib/layout-xkbswitch.py
+++ b/bumblebee_status/modules/contrib/layout-xkbswitch.py
@@ -19,13 +19,13 @@ class Module(core.module.Module):
     def __init__(self, config, theme):
         super().__init__(config, theme, core.widget.Widget(self.current_layout))
 
-        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.__next_keymap)
+        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.next_keymap)
         self.__current_layout = self.__get_current_layout()
 
     def current_layout(self, _):
         return self.__current_layout
 
-    def __next_keymap(self, event):
+    def next_keymap(self, event):
         util.cli.execute("xkb-switch -n", ignore_errors=True)
 
     def __get_current_layout(self):

--- a/tests/modules/contrib/test_layout-xkbswitch.py
+++ b/tests/modules/contrib/test_layout-xkbswitch.py
@@ -1,7 +1,58 @@
 import pytest
 
+import util.cli
+import core.config
+import modules.contrib.layout_xkbswitch
+
+def build_module():
+    return modules.contrib.layout_xkbswitch.Module(
+        config=core.config.Config([]),
+        theme=None
+    )
+
 def test_load_module():
     __import__("modules.contrib.layout-xkbswitch")
 
 def test_load_symbolic_link_module():
     __import__("modules.contrib.layout_xkbswitch")
+
+def test_current_layout(mocker):
+    command = mocker.patch('util.cli.execute')
+    command.side_effect = ['en', 'en']
+
+    module = build_module()
+    widget = module.widget()
+
+    module.update()
+
+    assert widget.full_text() == 'en'
+
+def test_current_layout_exception(mocker):
+    command = mocker.patch('util.cli.execute')
+    command.side_effect = RuntimeError
+
+    module = build_module()
+    widget = module.widget()
+
+    module.update()
+
+    assert widget.full_text() == ['n/a']
+
+def test_input_register(mocker):
+    input_register = mocker.patch('core.input.register')
+
+    module = build_module()
+
+    input_register.assert_called_with(
+        module,
+        button=core.input.LEFT_MOUSE,
+        cmd=module.next_keymap
+    )
+
+def test_next_keymap(mocker):
+    command = mocker.patch('util.cli.execute')
+
+    module = build_module()
+    module.next_keymap(False)
+
+    command.assert_called_with('xkb-switch -n', ignore_errors=True)


### PR DESCRIPTION
Hey!

This PRs creates tests for `layout-xkbswitch` module. :tada: 

The `__next_keymap` method now is a public method due to testing and... consistency, since this method is registered into `core.input.register`. I'm not sure about this. :thinking: 

Related issue: #641.