### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/bumblebee_status/core/module.py
+++ b/bumblebee_status/core/module.py
@@ -123,7 +123,7 @@ class Module(core.input.Object):
 
     def update_wrapper(self):
         if self.background == True:
-            if self.__thread and self.__thread.isAlive():
+            if self.__thread and self.__thread.is_alive():
                 return # skip this update interval
             self.__thread = threading.Thread(target=self.internal_update, args=(True,))
             self.__thread.start()

--- a/bumblebee_status/modules/contrib/apt.py
+++ b/bumblebee_status/modules/contrib/apt.py
@@ -65,7 +65,7 @@ class Module(core.module.Module):
         )
 
     def update(self):
-        if self.__thread and self.__thread.isAlive():
+        if self.__thread and self.__thread.is_alive():
             return
 
         self.__thread = threading.Thread(target=get_apt_check_info, args=(self,))

--- a/bumblebee_status/modules/core/redshift.py
+++ b/bumblebee_status/modules/core/redshift.py
@@ -101,7 +101,7 @@ class Module(core.module.Module):
         return val
 
     def update(self):
-        if self.__thread is not None and self.__thread.isAlive():
+        if self.__thread is not None and self.__thread.is_alive():
             return
         self.__thread = threading.Thread(target=get_redshift_value, args=(self,))
         self.__thread.start()


### PR DESCRIPTION
Replaced `threading.Thread.isAlive()` with `threading.Thread.is_alive()`

Fixes #726 