### PR TITLE
Provide alternative dunstctl implementation

### DIFF
--- a/bumblebee_status/modules/contrib/dunstctl.py
+++ b/bumblebee_status/modules/contrib/dunstctl.py
@@ -1,43 +1,42 @@
 # pylint: disable=C0111,R0903
 
-"""
-Toggle dunst notifications using dunstctl.
+"""Toggle dunst notifications using dunstctl.
 
-When notifications are paused using this module dunst doesn't get killed and you'll keep getting notifications on the background that will be displayed when unpausing.
-This is specially useful if you're using dunst's scripting (https://wiki.archlinux.org/index.php/Dunst#Scripting), which requires dunst to be running. Scripts will be executed when dunst gets unpaused.
+When notifications are paused using this module dunst doesn't get killed and
+you'll keep getting notifications on the background that will be displayed when
+unpausing. This is specially useful if you're using dunst's scripting
+(https://wiki.archlinux.org/index.php/Dunst#Scripting), which requires dunst to
+be running. Scripts will be executed when dunst gets unpaused.
 
 Requires:
     * dunst v1.5.0+
 
 contributed by `cristianmiranda <https://github.com/cristianmiranda>`_ - many thanks!
+contributed by `joachimmathes <https://github.com/joachimmathes>`_ - many thanks!
 """
 
 import core.module
 import core.widget
 import core.input
-
 import util.cli
 
 
 class Module(core.module.Module):
     def __init__(self, config, theme):
         super().__init__(config, theme, core.widget.Widget(""))
-        self._paused = self.__isPaused()
-        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.toggle_status)
+        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.__toggle_state)
+        self.__states = {"unknown": ["unknown", "critical"],
+                         "true": ["muted", "warning"],
+                         "false": ["unmuted"]}
 
-    def toggle_status(self, event):
-        self._paused = self.__isPaused()
-
-        if self._paused:
-            util.cli.execute("dunstctl set-paused false")
-        else:
-            util.cli.execute("dunstctl set-paused true")
-        self._paused = not self._paused
-
-    def __isPaused(self):
-        return util.cli.execute("dunstctl is-paused").strip() == "true"
+    def __toggle_state(self, event):
+        util.cli.execute("dunstctl set-paused toggle", ignore_errors=True)
 
     def state(self, widget):
-        if self._paused:
-            return ["muted", "warning"]
-        return ["unmuted"]
+        return self.__states[self.__is_dunst_paused()]
+
+    def __is_dunst_paused(self):
+        result = util.cli.execute("dunstctl is-paused",
+                                  return_exitcode=True,
+                                  ignore_errors=True)
+        return result[1].rstrip() if result[0] == 0 else "unknown"

--- a/themes/icons/ascii.json
+++ b/themes/icons/ascii.json
@@ -355,6 +355,17 @@
       "prefix": "dunst"
     }
   },
+  "dunstctl": {
+    "muted": {
+      "prefix": "dunst(muted)"
+    },
+    "unmuted": {
+      "prefix": "dunst"
+    },
+    "unknown": {
+      "prefix": "dunst(unknown)"
+    }
+  },
   "twmn": {
     "muted": {
       "prefix": "twmn"

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -259,7 +259,8 @@
   },
   "dunstctl": {
     "muted": { "prefix": "" },
-    "unmuted": { "prefix": "" }
+    "unmuted": { "prefix": "" },
+    "unknown": { "prefix": "" }
   },
   "twmn": {
     "muted": { "prefix": "" },

--- a/themes/icons/ionicons.json
+++ b/themes/icons/ionicons.json
@@ -187,6 +187,11 @@
     "muted": { "prefix": "\uf39a" },
     "unmuted": { "prefix": "\uf39b" }
   },
+  "dunstctl": {
+    "muted": { "prefix": "\uf39a" },
+    "unmuted": { "prefix": "\uf39b" },
+    "unknown": { "prefix": "\uf142" }
+  },
   "twmn": {
     "muted": { "prefix": "\uf1f6" },
     "unmuted": { "prefix": "\uf0f3" }


### PR DESCRIPTION
Hey @tobi-wan-kenobi,

I realize that a `dunstctl` module has already been provided. So, why this PR?
TL;DR: I didn't check the main branch. :roll_eyes:

I'm currently running the latest bumblebee-status version 2.0.5 on my system (since its production I stick to dedicated version tags instead of the main branch), but I wanted the `dunst` module to make use of the `dunsctl` cli, which was introduced in dunst v1.5.0. So, I started to implement a new `dunstctl` module, with the intent to provide a PR, but apparently without checking main first :roll_eyes:. When I was finally preparing my implementation for a PR, I realized that @cristianmiranda has already provided this feature. I could have deleted my code and just switched to main, but I decided to let the project maintainers decide, if my implementation is worth a look. :slightly_smiling_face: Thus, my effort is not in vain and since my approach is a little bit different some value might be added. The implementation
* is avoiding to cache the current state by making use of the dunstctl toggle functionality
* introduces a third state _unknown_, if dunst is not running.

I know that there is a test for `dunstctl` module, which I will adjust, of course, depending on your decision. Please let me know what you think.