### PR TITLE
update python name in shebang to respect PEP-0394

### DIFF
--- a/bumblebee-status
+++ b/bumblebee-status
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
If python2 is not available anymore there might be the case, that no python is available with the name {{python}}, eg. on debian bullseye.