### PR TITLE
Add mask for avahi duplicate interfaces

### DIFF
--- a/bumblebee_status/modules/core/nic.py
+++ b/bumblebee_status/modules/core/nic.py
@@ -93,7 +93,8 @@ class Module(core.module.Module):
     def _update_widgets(self, widgets):
         self.clear_widgets()
         interfaces = [
-            i for i in netifaces.interfaces() if not i.startswith(self._exclude)
+            i for i in netifaces.interfaces()
+            if not i.startswith(self._exclude) and ":" not in i
         ]
         interfaces.extend([i for i in netifaces.interfaces() if i in self._include])
 


### PR DESCRIPTION
Hi, me again,

I don't know if this a pervasive issue, but I've found that for some reason (haven't investigated it particularly much, tbh) interfaces are sometimes duplicated and amended with `:avahi`, which this now masks out.

Cheers