### PR TITLE
[modules/playerctl] Add format and layout parameters

### DIFF
--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -5,57 +5,113 @@
 Requires the following executable:
     * playerctl
 
-contributed by `smitajit <https://github.com/smitajit>`_ - many thanks!
+Parameters:
+    * playerctl.format:   Format string (defaults to '{artist} - {title}')
+      Available values are: {album}, {title}, {artist}, {trackNumber}
+    * playerctl.layout:   Comma-separated list to change order of widgets (defaults to song, previous, pause, next)
+      Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
 
+Parameters are inherited from `spotify` module, many thanks to its developers!
+
+contributed by `smitajit <https://github.com/smitajit>`_ - many thanks!
 """
 
 import core.module
 import core.widget
 import core.input
 import util.cli
+import util.format
+
+import logging
 
 class Module(core.module.Module):
-    def __init__(self,config , theme):
-        widgets = [
-            core.widget.Widget(name="playerctl.prev"),
-            core.widget.Widget(name="playerctl.main", full_text=self.description),
-            core.widget.Widget(name="playerctl.next"),
-        ]
-        super(Module, self).__init__(config, theme ,  widgets)
+    def __init__(self, config, theme):
+        super(Module, self).__init__(config, theme, [])
 
-        core.input.register(widgets[0], button=core.input.LEFT_MOUSE,
-            cmd="playerctl previous")
-        core.input.register(widgets[1], button=core.input.LEFT_MOUSE,
-             cmd="playerctl play-pause")
-        core.input.register(widgets[2], button=core.input.LEFT_MOUSE,
-             cmd="playerctl next")
+        self.background = True
 
-        self._status = None
-        self._tags = None
+        self.__layout = util.format.aslist(
+            self.parameter(
+                "layout", "playerctl.prev, playerctl.song, playerctl.pause, playerctl.next"
+            )
+        )
 
-    def description(self, widget):
-        return self._tags if self._tags else "..."
+        self.__song = ""
+        self.__cmd = "playerctl "
+        self.__format = self.parameter("format", "{artist} - {title}")
+
+        widget_map = {}
+        for widget_name in self.__layout:
+            widget = self.add_widget(name=widget_name)
+            if widget_name == "playerctl.prev":
+                widget_map[widget] = {
+                    "button": core.input.LEFT_MOUSE,
+                    "cmd": self.__cmd + "previous",
+                }
+                widget.set("state", "prev")
+            elif widget_name == "playerctl.pause":
+                widget_map[widget] = {
+                    "button": core.input.LEFT_MOUSE,
+                    "cmd": self.__cmd + "play-pause",
+                }
+            elif widget_name == "playerctl.next":
+                widget_map[widget] = {
+                    "button": core.input.LEFT_MOUSE,
+                    "cmd": self.__cmd + "next",
+                }
+                widget.set("state", "next")
+            elif widget_name == "playerctl.song":
+                widget_map[widget] = [
+                    {
+                        "button": core.input.LEFT_MOUSE,
+                        "cmd": self.__cmd + "play-pause",
+                    }, {
+                        "button": core.input.WHEEL_UP,
+                        "cmd": self.__cmd + "next",
+                    }, {
+                        "button": core.input.WHEEL_DOWN,
+                        "cmd": self.__cmd + "previous",
+                    }
+                ]
+            else:
+                raise KeyError(
+                    "The playerctl module does not have a {widget_name!r} widget".format(
+                        widget_name=widget_name
+                    )
+                )
+
+        for widget, callback_options in widget_map.items():
+            if isinstance(callback_options, dict):
+                core.input.register(widget, **callback_options)
 
     def update(self):
-        self._load_song()
-
-    def state(self, widget):
-        if widget.name == "playerctl.prev":
-            return "prev"
-        if widget.name == "playerctl.next":
-            return "next"
-        return self._status
-
-    def _load_song(self):
-        info = ""
         try:
-            status = util.cli.execute("playerctl status").lower()
-            info = util.cli.execute("playerctl metadata xesam:title")
-        except :
-            self._status = None
-            self._tags = None
-            return
-        self._status = status.split("\n")[0].lower()
-        self._tags = info.split("\n")[0][:20]
+            self.__get_song()
 
-# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+            for widget in self.widgets():
+                if widget.name == "playerctl.pause":
+                    playback_status = str(util.cli.execute(self.__cmd + "status")).strip()
+                    if playback_status != "":
+                        if playback_status == "Playing":
+                            widget.set("state", "playing")
+                        else:
+                            widget.set("state", "paused")
+                elif widget.name == "playerctl.song":
+                    widget.set("state", "song")
+                    widget.full_text(self.__song)
+        except Exception as e:
+            logging.exception(e)
+            self.__song = ""
+
+    def __get_song(self):
+        album = str(util.cli.execute(self.__cmd + "metadata xesam:album")).strip()
+        title = str(util.cli.execute(self.__cmd + "metadata xesam:title")).strip()
+        artist = str(util.cli.execute(self.__cmd + "metadata xesam:albumArtist")).strip()
+        track_number = str(util.cli.execute(self.__cmd + "metadata xesam:trackNumber")).strip()
+
+        self.__song = self.__format.format(
+            album = album,
+            title = title,
+            artist = artist,
+            track_number = track_number
+        )

--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -113,5 +113,5 @@ class Module(core.module.Module):
             album = album,
             title = title,
             artist = artist,
-            track_number = track_number
+            trackNumber = track_number
         )


### PR DESCRIPTION
This PR adds format and layout parameters similar to `spotify` module (https://github.com/tobi-wan-kenobi/bumblebee-status/issues/750#issuecomment-748465878).

Right now, the module calls to the `playerctl` shell program via `util.cli.execute`, which can be slow and unreliable.

I wanted to rewrite the module to support the [playerctl API library](https://github.com/altdesktop/playerctl#using-the-library), but I found the documentation incredibly lacking and not enough to write something functional with it (if you feel otherwise, please use it).