### PR TITLE
Add parameter to specify a configuration file

### DIFF
--- a/bumblebee_status/core/config.py
+++ b/bumblebee_status/core/config.py
@@ -148,6 +148,13 @@ class Config(util.store.Store):
             description="bumblebee-status is a modular, theme-able status line generator for the i3 window manager. https://github.com/tobi-wan-kenobi/bumblebee-status/wiki"
         )
         parser.add_argument(
+            "-c",
+            "--config-file",
+            action="store",
+            default=None,
+            help="Specify a configuration file to use"
+        )
+        parser.add_argument(
             "-m", "--modules", nargs="+", action="append", default=[], help=MODULE_HELP
         )
         parser.add_argument(
@@ -203,13 +210,18 @@ class Config(util.store.Store):
 
         self.__args = parser.parse_args(args)
 
-        for cfg in [
-            "~/.bumblebee-status.conf",
-            "~/.config/bumblebee-status.conf",
-            "~/.config/bumblebee-status/config",
-        ]:
+        if self.__args.config_file:
+            cfg = self.__args.config_file
             cfg = os.path.expanduser(cfg)
             self.load_config(cfg)
+        else:
+            for cfg in [
+                "~/.bumblebee-status.conf",
+                "~/.config/bumblebee-status.conf",
+                "~/.config/bumblebee-status/config",
+            ]:
+                cfg = os.path.expanduser(cfg)
+                self.load_config(cfg)
 
         parameters = [item for sub in self.__args.parameters for item in sub]
         for param in parameters:


### PR DESCRIPTION
Hello, 
Like many of us, I am using a two display setup, I wanted to have different bars showing different information. 
It was not possible to instruct bumblebee-status to use selected / given configuration file (as it iterates over three preselected locations only).
I have created a working setup meeting this requirement, I am starting two status_commands in i3wm like this:
```
bar {
  position top
  output %DISP_INT
  tray_output %DISP_INT
  status_command /usr/bin/bumblebee-status -c ~/.config/bumblebee-status/config_main
}
bar {
  position bottom
  output %DISP_EXT
  tray_output none
  status_command /usr/bin/bumblebee-status -c ~/.config/bumblebee-status/config_external
}
```
I have now two different bars with separate configurations running. 
I love bumblebee-status and thank you for your work on it.