### PR TITLE
Add code to enable scrolling of shell module output

### DIFF
--- a/bumblebee_status/modules/contrib/shell.py
+++ b/bumblebee_status/modules/contrib/shell.py
@@ -54,6 +54,7 @@ class Module(core.module.Module):
     def set_output(self, value):
         self.__output = value
 
+    @core.decorators.scrollable
     def get_output(self, _):
         return self.__output
 


### PR DESCRIPTION
In scenarios requiring use of own shell modules it is impossible to scroll wide output produced by shell module. Let's consider the following scenario:
```
[core]
modules=shell:crypto

[module-parameters]
# shell:crypto
crypto.command=bash -c 'printf "=%.2f$ XRP=%.2f$ ADA=%.2f$" $(curl -s rate.sx/1BTC) $(curl -s rate.sx/1XRP) $(curl -s rate.sx/1ADA)'
crypto.async=true
crypto.scrolling.width=15
crypto.scrolling.bounce=true
```

Without the modification proposed the following static full-width shell module output will be produced:
![Selection_330](https://user-images.githubusercontent.com/27959059/109331728-7b3fc300-785d-11eb-9e3d-0c8e467500d7.png)

With the modification proposed the following narrowed bouncing / scrolling output is possible:
![Selection_331](https://user-images.githubusercontent.com/27959059/109331747-84c92b00-785d-11eb-82c6-da3083d57015.png)


