### PR TITLE
Set default scrolling width to match text length

### DIFF
--- a/bumblebee_status/core/decorators.py
+++ b/bumblebee_status/core/decorators.py
@@ -74,7 +74,7 @@ def scrollable(func):
             widget.set("scrolling.direction", "right")
         widget.set("__content__", text)
 
-        width = util.format.asint(module.parameter("scrolling.width", 30))
+        width = util.format.asint(module.parameter("scrolling.width", len(text)))
         if util.format.asbool(module.parameter("scrolling.makewide", True)):
             widget.set("theme.minwidth", "A" * width)
         if width < 0 or len(text) <= width:


### PR DESCRIPTION
Making the output of the 'shell' module scrollable led to the introduction of a good deal of white space for my setup since the text I output is quite short.

I found that I was able to correct this by either setting the parameter `shell.scrolling.width` to the exact width of my output, or by setting `shell.scrolling.makewide` to `False`.

I wonder if you might consider making one of these the default setting for the parameter. It might make it less confusing for any newcomers trying to understand where the white space is coming from if their output is of length less than 30.