### PR TITLE
[modules/playerctl]: use `playerctl -f` and add `playerctl.args`

### DIFF
--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -6,12 +6,14 @@ Requires the following executable:
     * playerctl
 
 Parameters:
-    * playerctl.format:   Format string (defaults to '{artist} - {title}')
-      Available values are: {album}, {title}, {artist}, {trackNumber}
+    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}')
+      The format string is passed to 'playerctl -f' as an argument. See the 'Format Strings' section of 'man playerctl' for more information.
     * playerctl.layout:   Comma-separated list to change order of widgets (defaults to song, previous, pause, next)
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
+    * playerctl.args:     The arguments added to playerctl.
+      You can check 'playerctl --help' or `its README <https://github.com/altdesktop/playerctl#using-the-cli>`_. For example, it could be '-p vlc,%any'.
 
-Parameters are inherited from `spotify` module, many thanks to its developers!
+Parameters are inspired by the `spotify` module, many thanks to its developers!
 
 contributed by `smitajit <https://github.com/smitajit>`_ - many thanks!
 """
@@ -36,9 +38,8 @@ class Module(core.module.Module):
             )
         )
 
-        self.__song = ""
-        self.__cmd = "playerctl "
-        self.__format = self.parameter("format", "{artist} - {title}")
+        self.__cmd = "playerctl " + self.parameter("args", "") + " "
+        self.__format = self.parameter("format", "{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}")
 
         widget_map = {}
         for widget_name in self.__layout:
@@ -48,7 +49,6 @@ class Module(core.module.Module):
                     "button": core.input.LEFT_MOUSE,
                     "cmd": self.__cmd + "previous",
                 }
-                widget.set("state", "prev")
             elif widget_name == "playerctl.pause":
                 widget_map[widget] = {
                     "button": core.input.LEFT_MOUSE,
@@ -59,7 +59,6 @@ class Module(core.module.Module):
                     "button": core.input.LEFT_MOUSE,
                     "cmd": self.__cmd + "next",
                 }
-                widget.set("state", "next")
             elif widget_name == "playerctl.song":
                 widget_map[widget] = [
                     {
@@ -86,32 +85,32 @@ class Module(core.module.Module):
 
     def update(self):
         try:
-            self.__get_song()
-
-            for widget in self.widgets():
-                if widget.name == "playerctl.pause":
-                    playback_status = str(util.cli.execute(self.__cmd + "status")).strip()
-                    if playback_status != "":
-                        if playback_status == "Playing":
-                            widget.set("state", "playing")
-                        else:
-                            widget.set("state", "paused")
-                elif widget.name == "playerctl.song":
-                    widget.set("state", "song")
-                    widget.full_text(self.__song)
+            playback_status = str(util.cli.execute(self.__cmd + "status")).strip()
         except Exception as e:
             logging.exception(e)
-            self.__song = ""
+            playback_status = None
+        for widget in self.widgets():
+            if playback_status:
+                if widget.name == "playerctl.pause":
+                    if playback_status == "Playing":
+                        widget.set("state", "playing")
+                    elif playback_status == "Paused":
+                        widget.set("state", "paused")
+                    else:
+                        widget.set("state", "")
+                elif widget.name == "playerctl.next":
+                    widget.set("state", "next")
+                elif widget.name == "playerctl.prev":
+                    widget.set("state", "prev")
+                elif widget.name == "playerctl.song":
+                    widget.full_text(self.__get_song())
+            else:
+                widget.set("state", "")
+                widget.full_text(" ")
 
     def __get_song(self):
-        album = str(util.cli.execute(self.__cmd + "metadata xesam:album")).strip()
-        title = str(util.cli.execute(self.__cmd + "metadata xesam:title")).strip()
-        artist = str(util.cli.execute(self.__cmd + "metadata xesam:albumArtist")).strip()
-        track_number = str(util.cli.execute(self.__cmd + "metadata xesam:trackNumber")).strip()
-
-        self.__song = self.__format.format(
-            album = album,
-            title = title,
-            artist = artist,
-            trackNumber = track_number
-        )
+        try:
+            return str(util.cli.execute(self.__cmd + "metadata -f '" + self.__format + "'")).strip()
+        except Exception as e:
+            logging.exception(e)
+            return " "

--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -6,8 +6,8 @@ Requires the following executable:
     * playerctl
 
 Parameters:
-    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}')
-      The format string is passed to 'playerctl -f' as an argument. See the 'Format Strings' section of 'man playerctl' for more information.
+    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}').
+      The format string is passed to 'playerctl -f' as an argument. Read `the README <https://github.com/altdesktop/playerctl#printing-properties-and-metadata>`_ for more information.
     * playerctl.layout:   Comma-separated list to change order of widgets (defaults to song, previous, pause, next)
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
     * playerctl.args:     The arguments added to playerctl.

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1060,12 +1060,14 @@ Requires the following executable:
     * playerctl
 
 Parameters:
-    * playerctl.format:   Format string (defaults to '{artist} - {title}')
-      Available values are: {album}, {title}, {artist}, {trackNumber}
+    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}')
+      The format string is passed to 'playerctl -f' as an argument. See the 'Format Strings' section of 'man playerctl' for more information.
     * playerctl.layout:   Comma-separated list to change order of widgets (defaults to song, previous, pause, next)
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
+    * playerctl.args:     The arguments added to playerctl.
+      You can check 'playerctl --help' or `its readme <https://github.com/altdesktop/playerctl#using-the-cli>`_. For example, it could be '-p vlc,%any'.
 
-Parameters are inherited from `spotify` module, many thanks to its developers!
+Parameters are inspired by the `spotify` module, many thanks to its developers!
 
 contributed by `smitajit <https://github.com/smitajit>`_ - many thanks!
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1060,8 +1060,8 @@ Requires the following executable:
     * playerctl
 
 Parameters:
-    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}')
-      The format string is passed to 'playerctl -f' as an argument. See the 'Format Strings' section of 'man playerctl' for more information.
+    * playerctl.format:   Format string (defaults to '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}').
+      The format string is passed to 'playerctl -f' as an argument. Read `the README <https://github.com/altdesktop/playerctl#printing-properties-and-metadata>`_ for more information.
     * playerctl.layout:   Comma-separated list to change order of widgets (defaults to song, previous, pause, next)
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
     * playerctl.args:     The arguments added to playerctl.


### PR DESCRIPTION
1. Use `playerctl -f` to format, which is more powerful. This also fixes #767, which is caused by missing a few fields of the metadata.
2. Add `playerctl.args`, so that users can choose a specific player, etc.
3. Display nothing when there's no running player.

This is a breaking change. Users need to change `{title}` to `{{title}}`.

I'm not sure how should I handle a breaking change. Should I add a new parameter like `playerctl.playerctl_format`, or replace `{artist}` with `{{artist}}`, or just break it?