### PR TITLE
Add active gpu module using optimus-manager

### DIFF
--- a/bumblebee_status/modules/contrib/optman.py
+++ b/bumblebee_status/modules/contrib/optman.py
@@ -1,0 +1,36 @@
+"""Displays currently active gpu by optimus-manager
+Requires the following packages:
+
+    * optimus-manager
+
+"""
+
+import subprocess
+
+import core.module
+import core.widget
+
+
+class Module(core.module.Module):
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.output))
+        self.__gpumode = ""
+
+    def output(self, _):
+        return "GPU: {}".format(self.__gpumode)
+
+    def update(self):
+        cmd = ["optimus-manager", "--print-mode"]
+        output = (
+            subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            .communicate()[0]
+            .decode("utf-8")
+            .lower()
+        )
+
+        if "intel" in output:
+            self.__gpumode = "Intel"
+        elif "nvidia" in output:
+            self.__gpumode = "Nvidia"
+        elif "amd" in output:
+            self.__gpumode = "AMD"


### PR DESCRIPTION
I was searching for a little module that could show me my active GPU (intel/nvidia) but ended up making one by myself after failing to find one. For those who use optimus-manager to switch between GPUs, this helps determine the active one.

Looks something like: 
![image](https://user-images.githubusercontent.com/16357214/123310342-9c7e9a80-d543-11eb-8a0c-3d89fc1bb531.png)
