### PR TITLE
fix: correct mem usage to be mem *io* usage

### DIFF
--- a/bumblebee_status/modules/contrib/nvidiagpu.py
+++ b/bumblebee_status/modules/contrib/nvidiagpu.py
@@ -4,11 +4,15 @@
 
 Parameters:
    * nvidiagpu.format: Format string (defaults to '{name}: {temp}°C %{usedmem}/{totalmem} MiB')
-     Available values are: {name} {temp} {mem_used} {mem_total} {fanspeed} {clock_gpu} {clock_mem} {gpu_usage_pct} {mem_usage_pct}
+     Available values are: {name} {temp} {mem_used} {mem_total} {fanspeed} {clock_gpu} {clock_mem} {gpu_usage_pct} {mem_usage_pct} {mem_io_pct}
 
 Requires nvidia-smi
 
 contributed by `RileyRedpath <https://github.com/RileyRedpath>`_ - many thanks!
+
+Note: mem_io_pct is (from `man nvidia-smi`):
+> Percent of time over the past sample period during which global (device)
+> memory was being read or written.
 """
 
 import core.module
@@ -42,7 +46,8 @@ class Module(core.module.Module):
         clockGpu = ""
         fanspeed = ""
         gpuUsagePct = ""
-        memPct = ""
+        memIoPct = ""
+        memUsage = "not found"
         for item in sp.split("\n"):
             try:
                 key, val = item.split(":")
@@ -67,10 +72,13 @@ class Module(core.module.Module):
                     if key == "Gpu":
                         gpuUsagePct = val.split(" ")[0]
                     elif key == "Memory":
-                        memPct = val.split(" ")[0]
+                        memIoPct = val.split(" ")[0]
 
             except:
                 title = item.strip()
+
+        if totalMem and usedMem:
+            memUsage = int(int(usedMem) / int(totalMem) * 100)
 
         str_format = self.parameter(
             "format", "{name}: {temp}°C {mem_used}/{mem_total} MiB"
@@ -84,7 +92,8 @@ class Module(core.module.Module):
             clock_mem=clockMem,
             fanspeed=fanspeed,
             gpu_usage_pct=gpuUsagePct,
-            mem_usage_pct=memPct,
+            mem_io_pct=memIoPct,
+            mem_usage_pct=memUsage,
         )
 
 


### PR DESCRIPTION
I realised I made a mistake in [my previous pr](https://github.com/tobi-wan-kenobi/bumblebee-status/pull/806). The memory percentage value that I added was *not* the used/total usage of the memory itself. Instead it was actually the memory IO time :man_facepalming:. I should've RTFM first.

This PR fixes that mistake and renames the value to what it actually is. Plus it adds the "used/total as a percentage" value that I wanted all along.

Sorry for the mixup :grimacing: 