### PR TITLE
Introduce threshold dependent shell output coloring with unit present…

### DIFF
--- a/bumblebee_status/modules/contrib/shell.py
+++ b/bumblebee_status/modules/contrib/shell.py
@@ -40,6 +40,7 @@ class Module(core.module.Module):
     def __init__(self, config, theme):
         super().__init__(config, theme, core.widget.Widget(self.get_output))
 
+        self.__unit= self.parameter("unit", 'echo "no unit configured"')
         self.__command = self.parameter("command", 'echo "no command configured"')
         self.__async = util.format.asbool(self.parameter("async"))
 
@@ -55,7 +56,7 @@ class Module(core.module.Module):
         self.__output = value
 
     def get_output(self, _):
-        return self.__output
+        return self.__output + str(self.parameter("unit"))
 
     def update(self):
         # if requested then run not async version and just execute command in this thread
@@ -77,8 +78,25 @@ class Module(core.module.Module):
         self.__current_thread.start()
 
     def state(self, _):
-        if self.__output == "no command configured":
-            return "warning"
+        if self.parameter("unit") is None:
+            if self.__output == "no command configured":
+                return "critical"
+        else:
+            if self.parameter("warning") is None:
+                warning_threshold = 75
+            else:
+                warning_threshold = float(self.parameter("warning"))
+
+            if self.parameter("critical") is None:
+                critical_threshold = 90
+            else:
+                critical_threshold = float(self.parameter("critical"))
+
+            if float(self.__output) > critical_threshold:
+                return "critical"
+
+            if float(self.__output) > warning_threshold:
+                return "warning"
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
…ation

Let's assume we want to have visual alerts (background color change) depending on specific measurable value coming as a result of shell action. This patch makes this possible:

- Call the module

```
[core]
modules=...,shell:temperature,...
```

- Configure the module (the trigger is to define **unit**)

```
# shell:temperature
temperature.command=bash -c 'echo $(cat /sys/class/thermal/thermal_zone0/temp | cut -c 1-2)'
temperature.unit=°C
temperature.warning=75
temperature.critical=85
```

The possible results:
![image](https://user-images.githubusercontent.com/27959059/134051568-293aebbc-333a-469e-8998-692ecb8c0cca.png)
![image](https://user-images.githubusercontent.com/27959059/134051717-f9832c8f-cbf6-439d-8338-fb69995588cb.png)
![image](https://user-images.githubusercontent.com/27959059/134051850-20dd06a5-4bbe-4b6b-989f-a1f5ef0d56f3.png)

There might be better ideas to solve this requirement and for sure better ways to implement it. If there would be any comments and / or suggestions to make it better, I am open to any critics (even non constructive).