### PR TITLE
[modules/sensors] auto-determine the correct thermal zone

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1195,6 +1195,8 @@ sensors
 Displays sensor temperature
 
 Parameters:
+    * sensors.use_sensors (True/False): whether to use the 'sensors' command.
+      If set to 'False', the sysfs-interface at '/sys/class/thermal' is used
     * sensors.path: path to temperature file (default /sys/class/thermal/thermal_zone0/temp).
     * sensors.json: if set to 'true', interpret sensors.path as JSON 'path' in the output
       of 'sensors -j' (i.e. <key1>/<key2>/.../<value>), for example, path could


### PR DESCRIPTION
The sensors module can now pick the correct thermal zone in the `/sys`-interface automaticly.

Also added a parameter whether to use the `sensors` command or `/sys` (this was previously done by checking whether the path-parameter was passed, which is now no longer necessary due to auto-detection).

Updated the docs as well (info about the new parameter).