### PR TITLE
[modules/sensors] use util.format.asbool()

### DIFF
--- a/bumblebee_status/modules/contrib/sensors.py
+++ b/bumblebee_status/modules/contrib/sensors.py
@@ -4,6 +4,7 @@
 """Displays sensor temperature
 
 Parameters:
+    * sensors.use_sensors: whether to use the sensors command
     * sensors.path: path to temperature file (default /sys/class/thermal/thermal_zone0/temp).
     * sensors.json: if set to 'true', interpret sensors.path as JSON 'path' in the output
       of 'sensors -j' (i.e. <key1>/<key2>/.../<value>), for example, path could
@@ -47,28 +48,25 @@ class Module(core.module.Module):
         self._json = util.format.asbool(self.parameter("json", False))
         self._freq = util.format.asbool(self.parameter("show_freq", True))
         core.input.register(self, button=core.input.LEFT_MOUSE, cmd="xsensors")
-        self.determine_method()
+        self.use_sensors = self.determine_method()
 
     def determine_method(self):
-        if self.parameter("use_sensors") == "True":
-            self.use_sensors = True
-            return
-        if self.parameter("use_sensors") == "False":
-            self.use_sensors = False
-            return
+        if util.format.asbool(self.parameter("use_sensors")) == True:
+            return True
+        if util.format.asbool(self.parameter("use_sensors")) == False:
+            return False
         if self.parameter("path") != None and self._json == False:
-            self.use_sensors = False # use thermal zone
-            return
+            return False
         # try to use output of sensors -u
         try:
-            output = util.cli.execute("sensors -u")
-            self.use_sensors = True
+            _ = util.cli.execute("sensors -u")
             log.debug("Sensors command available")
+            return True
         except FileNotFoundError as e:
             log.info(
                 "Sensors command not available, using /sys/class/thermal/thermal_zone*/"
             )
-            self.use_sensors = False
+            return False
 
     def _get_temp_from_sensors(self):
         if self._json == True:
@@ -107,12 +105,13 @@ class Module(core.module.Module):
             if self.parameter("path") is not None:
                 path = self.parameter("path")
             # find the thermal zone that provides cpu temperature
-            for zone in os.listdir("/sys/class/thermal"):
-                if not zone.startswith("thermal_zone"):
-                    continue
-                if open(f"/sys/class/thermal/{zone}/type").read().strip() != "x86_pkg_temp":
-                    continue
-                path = f"/sys/class/thermal/{zone}/temp"
+            else:
+                for zone in os.listdir("/sys/class/thermal"):
+                    if not zone.startswith("thermal_zone"):
+                        continue
+                    if open(f"/sys/class/thermal/{zone}/type").read().strip() != "x86_pkg_temp":
+                        continue
+                    path = f"/sys/class/thermal/{zone}/temp"
             # use zone 0 as fallback
             if path is None:
                 log.info("Can not determine temperature path, using thermal_zone0")

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1195,8 +1195,9 @@ sensors
 Displays sensor temperature
 
 Parameters:
-    * sensors.use_sensors (True/False): whether to use the 'sensors' command.
-      If set to 'False', the sysfs-interface at '/sys/class/thermal' is used
+    * sensors.use_sensors: whether to use the 'sensors' command.
+      If set to 'false', the sysfs-interface at '/sys/class/thermal' is used.
+      If not set, 'sensors' will be used if available.
     * sensors.path: path to temperature file (default /sys/class/thermal/thermal_zone0/temp).
     * sensors.json: if set to 'true', interpret sensors.path as JSON 'path' in the output
       of 'sensors -j' (i.e. <key1>/<key2>/.../<value>), for example, path could


### PR DESCRIPTION
Sorry, I didn't know about util.format.asbool()

I also checked the code once again and noticed that we should only auto-check the thermal zone if no path is provided as parameter.