### PR TITLE
[contrib/playerctl]: don't log when no player is found

### DIFF
--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -85,7 +85,9 @@ class Module(core.module.Module):
 
     def update(self):
         try:
-            playback_status = str(util.cli.execute(self.__cmd + "status")).strip()
+            playback_status = str(util.cli.execute(self.__cmd + "status 2>&1 || true", shell = True)).strip()
+            if playback_status == "No players found":
+                playback_status = None
         except Exception as e:
             logging.exception(e)
             playback_status = None


### PR DESCRIPTION
`playerctl status` returns 1 when no player is found, which caused contrib/playerctl to log many times when there's no player.