### PR TITLE
add updating view on apt-cache on click

### DIFF
--- a/bumblebee_status/modules/contrib/apt.py
+++ b/bumblebee_status/modules/contrib/apt.py
@@ -14,6 +14,7 @@ import threading
 import core.module
 import core.widget
 import core.decorators
+import core.input
 
 import util.cli
 
@@ -56,6 +57,8 @@ class Module(core.module.Module):
     def __init__(self, config, theme):
         super().__init__(config, theme, core.widget.Widget(self.updates))
         self.__thread = None
+        core.input.register(self, button=core.input.RIGHT_MOUSE,
+                            cmd=self.updates)
 
     def updates(self, widget):
         if widget.get("error"):


### PR DESCRIPTION
Not sure, if I should open the PR on the fork of the provider of the module... hope you like it anyway.

I saw, that updating the apt-cache does only refresh the display of the module after 30 Minutes max. So I thought it would be nice to be able to trigger that update by click.

Hope you like it.