### PR TITLE
Fix publicip

### DIFF
--- a/bumblebee_status/modules/contrib/sun.py
+++ b/bumblebee_status/modules/contrib/sun.py
@@ -39,7 +39,11 @@ class Module(core.module.Module):
         self.__sun = None
 
         if not lat or not lon:
-            lat, lon = util.location.coordinates()
+            try:
+                lat, lon = util.location.coordinates()
+            except Exception:
+                pass
+
         if lat and lon:
             self.__sun = Sun(float(lat), float(lon))
 
@@ -55,6 +59,10 @@ class Module(core.module.Module):
         return "n/a"
 
     def __calculate_times(self):
+        if not self.__sun:
+            self.__sunset = self.__sunrise = None
+            return
+
         self.__isup = False
 
         order_matters = True

--- a/bumblebee_status/util/location.py
+++ b/bumblebee_status/util/location.py
@@ -59,11 +59,11 @@ def __load():
     __next = time.time() + 60 * 30  # error - try again every 30m
 
 
-def __get(name, default=None):
+def __get(name):
     global __data
     if not __data or __expired():
         __load()
-    return __data.get(name, default)
+    return __data[name]
 
 
 def reset():


### PR DESCRIPTION
Fixes #853 

Calling `__data.get(name, default)` (in the `__get` method of `util/location.py`) results in no exception being raised if a key is not available (such as when an Internet connection is down and `__data` does not get filled). In this case, the `update` method of _publicip_ will not execute the `except` branch, but return `None` instead.

The _sun_ module is affected by this bug as well.