### PR TITLE
fix case of Kelvin SI unit in redshift widget

### DIFF
--- a/bumblebee_status/modules/core/redshift.py
+++ b/bumblebee_status/modules/core/redshift.py
@@ -54,7 +54,7 @@ def get_redshift_value(module):
     for line in res.split("\n"):
         line = line.lower()
         if "temperature" in line:
-            widget.set("temp", line.split(" ")[2])
+            widget.set("temp", line.split(" ")[2].upper())
         if "period" in line:
             state = line.split(" ")[1]
             if "day" in state:


### PR DESCRIPTION
In the `redshift` widget, currently the temperature gets lower-cased (`6500k`). This PR makes sure that the that the SI unit symbol for Kelvin gets displayed correctly (`6500K`).