### PR TITLE
[core/input] methods can be event callbacks

### DIFF
--- a/bumblebee_status/core/input.py
+++ b/bumblebee_status/core/input.py
@@ -54,8 +54,11 @@ def register(obj, button=None, cmd=None, wait=False):
     event_id = __event_id(obj.id if obj is not None else "", button)
     logging.debug("registering callback {}".format(event_id))
     core.event.unregister(event_id) # make sure there's always only one input event
+
     if callable(cmd):
         core.event.register_exclusive(event_id, cmd)
+    elif obj and hasattr(obj, cmd) and callable(getattr(obj, cmd)):
+        core.event.register_exclusive(event_id, lambda event: getattr(obj, cmd)(event))
     else:
         core.event.register_exclusive(event_id, lambda event: __execute(event, cmd, wait))
 

--- a/bumblebee_status/modules/core/spacer.py
+++ b/bumblebee_status/modules/core/spacer.py
@@ -9,7 +9,7 @@ Parameters:
 import core.module
 import core.widget
 import core.decorators
-
+import core.input
 
 class Module(core.module.Module):
     @core.decorators.every(minutes=60)
@@ -19,6 +19,9 @@ class Module(core.module.Module):
 
     def text(self, _):
         return self.__text
+
+    def update_text(self, event):
+        self.__text = core.input.button_name(event["button"])
 
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
When registering an event (especially mouse events), if the parameter
is a valid method in the Module, execute that with the event as
parameter.

Add this in the core.spacer module as an example.

fixes #858
see #857