### PR TITLE
refactor contrib.persian_date module

### DIFF
--- a/bumblebee_status/modules/contrib/persian_date.py
+++ b/bumblebee_status/modules/contrib/persian_date.py
@@ -10,36 +10,22 @@ Parameters:
     * datetime.locale: locale to use. default: "fa_IR"
 """
 
-from __future__ import absolute_import
 import jdatetime
-import locale
 
-import core.module
-import core.widget
-import core.input
+import core.decorators
+from modules.core.datetime import Module as dtmodule
 
 
-class Module(core.module.Module):
+class Module(dtmodule):
+    @core.decorators.every(minutes=1)
     def __init__(self, config, theme):
-        super().__init__(config, theme, core.widget.Widget(self.full_text))
-
-        l = ("fa_IR", "UTF-8")
-        lcl = self.parameter("locale", ".".join(l))
-        try:
-            locale.setlocale(locale.LC_ALL, lcl.split("."))
-        except Exception as e:
-            locale.setlocale(locale.LC_ALL, ("fa_IR", "UTF-8"))
+        super().__init__(config, theme, dtlibrary=jdatetime)
 
     def default_format(self):
         return "%A %d %B"
 
-    def full_text(self, widget):
-        enc = locale.getpreferredencoding()
-        fmt = self.parameter("format", self.default_format())
-        retval = jdatetime.datetime.now().strftime(fmt)
-        if hasattr(retval, "decode"):
-            return retval.decode(enc)
-        return retval
+    def default_locale(self):
+        return ("fa_IR", "UTF-8")
 
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/bumblebee_status/modules/core/datetime.py
+++ b/bumblebee_status/modules/core/datetime.py
@@ -17,26 +17,33 @@ import core.input
 
 
 class Module(core.module.Module):
-    def __init__(self, config, theme):
+    def __init__(self, config, theme, dtlibrary=None):
         super().__init__(config, theme, core.widget.Widget(self.full_text))
 
         core.input.register(self, button=core.input.LEFT_MOUSE, cmd="calendar")
-        l = locale.getdefaultlocale()
+        self.dtlibrary = dtlibrary or datetime
+
+    def set_locale(self):
+        l = self.default_locale()
         if not l or l == (None, None):
             l = ("en_US", "UTF-8")
         lcl = self.parameter("locale", ".".join(l))
         try:
-            locale.setlocale(locale.LC_TIME, lcl.split("."))
+            locale.setlocale(locale.LC_ALL, lcl.split("."))
         except Exception as e:
-            locale.setlocale(locale.LC_TIME, ("en_US", "UTF-8"))
+            locale.setlocale(locale.LC_ALL, ("en_US", "UTF-8"))
 
     def default_format(self):
         return "%x %X"
 
+    def default_locale(self):
+        return locale.getdefaultlocale()
+
     def full_text(self, widget):
+        self.set_locale()
         enc = locale.getpreferredencoding()
         fmt = self.parameter("format", self.default_format())
-        retval = datetime.datetime.now().strftime(fmt)
+        retval = self.dtlibrary.datetime.now().strftime(fmt)
         if hasattr(retval, "decode"):
             return retval.decode(enc)
         return retval


### PR DESCRIPTION
I have added a `dtlibrary` attribute to `datetime` module. now other modules can subclass this module and set their own library to be used.

also, note that I had to use `LC_ALL` instead of `LC_TIME` for `jdatetime` to work correctly. I'm not sure if it had disturbed any other module. I'm not seeing any issue with the modules I have been using right now.