### PR TITLE
Add hide parameter to playerctl

### DIFF
--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -12,6 +12,7 @@ Parameters:
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
     * playerctl.args:     The arguments added to playerctl.
       You can check 'playerctl --help' or `its README <https://github.com/altdesktop/playerctl#using-the-cli>`_. For example, it could be '-p vlc,%any'.
+    * playerctl.hide:   Hide the widgets when no players are found. Defaults to "false".
 
 Parameters are inspired by the `spotify` module, many thanks to its developers!
 
@@ -31,6 +32,8 @@ class Module(core.module.Module):
         super(Module, self).__init__(config, theme, [])
 
         self.background = True
+
+        self.__hide = util.format.asbool(self.parameter("hide", "false"));
 
         self.__layout = util.format.aslist(
             self.parameter(
@@ -83,14 +86,20 @@ class Module(core.module.Module):
             if isinstance(callback_options, dict):
                 core.input.register(widget, **callback_options)
 
-    def update(self):
+    def hidden(self):
+        return self.__hide and self.status() == None
+
+    def status(self):
         try:
             playback_status = str(util.cli.execute(self.__cmd + "status 2>&1 || true", shell = True)).strip()
             if playback_status == "No players found":
-                playback_status = None
+                return None
+            return playback_status
         except Exception as e:
             logging.exception(e)
-            playback_status = None
+            return None
+
+    def update(self):
         for widget in self.widgets():
             if playback_status:
                 if widget.name == "playerctl.pause":

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1095,6 +1095,7 @@ Parameters:
       Widget names are: playerctl.song, playerctl.prev, playerctl.pause, playerctl.next
     * playerctl.args:     The arguments added to playerctl.
       You can check 'playerctl --help' or `its readme <https://github.com/altdesktop/playerctl#using-the-cli>`_. For example, it could be '-p vlc,%any'.
+    * playerctl.hide:   Hide the widgets when no players are found. Defaults to "false".
 
 Parameters are inspired by the `spotify` module, many thanks to its developers!
 


### PR DESCRIPTION
This PR adds the `hide` parameter to playerctl so that its widgets can be hidden when no players are found. Currently it populates the bar with empty widgets when no players are found, which isn't great.

Because two functions now require the playback status, I refactored that functionality out into its own function.