### PR TITLE
Fix logout item using hardcoded command

### DIFF
--- a/bumblebee_status/modules/contrib/system.py
+++ b/bumblebee_status/modules/contrib/system.py
@@ -96,7 +96,7 @@ class Module(core.module.Module):
         menu.add_menuitem(
             "log out",
             callback=functools.partial(
-                self.__on_command, "Log out", "Log out?", "i3exit logout"
+                self.__on_command, "Log out", "Log out?", logout_cmd
             ),
         )
         # don't ask for these


### PR DESCRIPTION
Command was hard coded in instead of using the configurable parameter.