### PR TITLE
Hide progress module if it's inactive

### DIFF
--- a/bumblebee_status/modules/contrib/progress.py
+++ b/bumblebee_status/modules/contrib/progress.py
@@ -29,6 +29,9 @@ class Module(core.module.Module):
         super().__init__(config, theme, core.widget.Widget(self.get_progress_text))
         self.__active = False
 
+    def hidden(self):
+        return not self.__active
+
     def get_progress_text(self, widget):
         if self.update_progress_info(widget):
             width = util.format.asint(self.parameter("barwidth", 8))


### PR DESCRIPTION
This PR hides the progress module if it is inactive. This will break existing behaviour as it currently displays placeholder text when inactive, so I can make this new behaviour configurable if desired.