### PR TITLE
Add popup command parameter to the system module

### DIFF
--- a/bumblebee_status/modules/contrib/system.py
+++ b/bumblebee_status/modules/contrib/system.py
@@ -72,6 +72,11 @@ class Module(core.module.Module):
             util.cli.execute(command)
 
     def popup(self, widget):
+        popupcmd = self.parameter("popupcmd", "");
+        if (popupcmd != ""):
+            util.cli.execute(popupcmd)
+            return
+
         menu = util.popup.menu()
         reboot_cmd = self.parameter("reboot", "reboot")
         shutdown_cmd = self.parameter("shutdown", "shutdown -h now")

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1413,6 +1413,7 @@ Parameters:
         * system.lock: specify a command for locking the screen (defaults to 'i3exit lock')
         * system.suspend: specify a command for suspending (defaults to 'i3exit suspend')
         * system.hibernate: specify a command for hibernating (defaults to 'i3exit hibernate')
+        * system.popupcmd: specify a command to run instead of opening the default menu
         
 Requirements:
         tkinter (python3-tk package on debian based systems either you can install it as python package)


### PR DESCRIPTION
This PR adds the `popupcmd` parameter to the system module, allowing people to override what happens when the module is clicked. I find this useful to run a rofi menu instead of the default menu.