### PR TITLE
reduce spacing in awesome fonts iconset

### DIFF
--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -1,7 +1,7 @@
 {
   "defaults": {
     "separator": "",
-    "padding": " ",
+    "padding": " ",
     "unknown": {
       "prefix": ""
     },


### PR DESCRIPTION
This replaces the previous normal spacing character (which is the
usual ASCII 0x20 SPACE) by a *narrower* spacer (which is unicode
U+2009 THIN SPACE).

I found that space thanks to

https://en.wikipedia.org/wiki/Space_(punctuation)#Types_of_spaces

... and specifically:

https://en.wikipedia.org/wiki/Thin_space

... and this actually works, amazingly. Probably because it is pretty
standard as it's part of the SI specification (thousands separator),
Tex (`\thinspace` or `\,`), and HTML (`&thinsp;`)

Closes: #888

Before:

![snap-20220615T115219](https://user-images.githubusercontent.com/796623/173871366-29692d65-f1c3-4f8e-ad4e-45e84724aefe.png)

After: 

![snap-20220615T115141](https://user-images.githubusercontent.com/796623/173871278-706a0e06-1670-4bc0-9e66-0a2e544b32f5.png)
