### PR TITLE
handle missing battery case

### DIFF
--- a/bumblebee_status/modules/contrib/battery-upower.py
+++ b/bumblebee_status/modules/contrib/battery-upower.py
@@ -207,6 +207,12 @@ class UPowerManager:
         data = upower_interface.GetTotal()
         return data
 
+    def is_battery_present(self, battery):
+        battery_proxy = self.bus.get_object(self.UPOWER_NAME, battery)
+        battery_proxy_interface = dbus.Interface(battery_proxy, self.DBUS_PROPERTIES)
+
+        return bool(battery_proxy_interface.Get(self.UPOWER_NAME + ".Device", "IsPresent"))
+
     def is_loading(self, battery):
         battery_proxy = self.bus.get_object(self.UPOWER_NAME, battery)
         battery_proxy_interface = dbus.Interface(battery_proxy, self.DBUS_PROPERTIES)
@@ -259,6 +265,11 @@ class Module(core.module.Module):
         widget.set("capacity", -1)
         widget.set("ac", False)
         output = "n/a"
+        if not self.power.is_battery_present(self.device):
+            widget.set("ac", True)
+            widget.set("capacity", 100)
+            output = "ac"
+            return output
         try:
             capacity = int(self.power.get_device_percentage(self.device))
             capacity = capacity if capacity < 100 else 100


### PR DESCRIPTION
I run the same bumblebee-status configuration on my laptop and my
workstation. On my laptop, the upower module works fine: it says "ac"
when plugged in, charging, all that stuff is great.

But on my workstation, it's completely broken: it thinks there's a
battery (which is a mistake: there is no battery at all, apart maybe
from the CMOS battery, but that's not covered by upower), and it
thinks it's discharged, which makes a very noisy warning in the bar.

Now maybe there's something wrong with dbus, Debian, the kernel,
Linux, or some thing else in the stack. All I know is that
`self.power.get_display_device()` returns something like a valid
dbus object here and from there it confuses the heck out of the
module.

So this just adds a function to check if the actual device we're
talking about is actually present, and bails earlier otherwise.

Before: battery logo and "0% 00:00m!", all marked as critical ("red")

After: "ac" with the plugged in logo, not marked critical ("black")