### PR TITLE
Hide battery module if there are no batteries

### DIFF
--- a/bumblebee_status/modules/contrib/battery.py
+++ b/bumblebee_status/modules/contrib/battery.py
@@ -134,6 +134,9 @@ class Module(core.module.Module):
             if util.format.asbool(self.parameter("decorate", True)) == False:
                 widget.set("theme.exclude", "suffix")
 
+    def hidden(self):
+        return len(self._batteries) == 0
+
     def ac(self, widget):
         return "ac"
 


### PR DESCRIPTION
This PR hides the battery module if there are no batteries in the system. If you share a configuration between a desktop and laptop then currently the desktop will show that it's plugged in (obvious if you ask me), so with this PR the desktop doesn't show anything, which is much nicer.