### PR TITLE
[modules/pamixer] use -t flag to toggle mute instead of setting volume level to 0

### DIFF
--- a/bumblebee_status/modules/contrib/pamixer.py
+++ b/bumblebee_status/modules/contrib/pamixer.py
@@ -49,7 +49,7 @@ class Module(core.module.Module):
             core.input.register(self, button=event["button"], cmd=event["action"])
 
     def toggle(self, event):
-        self.set_parameter("--set-level 0")
+        self.set_parameter("--toggle-mute")
 
     def increase_volume(self, event):
         self.set_parameter("--increase {}".format(self.__change))


### PR DESCRIPTION
setting volume to 0 was just wrong