### PR TITLE
Added task detail display for taskwarrior

### DIFF
--- a/bumblebee_status/modules/contrib/taskwarrior.py
+++ b/bumblebee_status/modules/contrib/taskwarrior.py
@@ -24,7 +24,12 @@ class Module(core.module.Module):
         self.__pending_tasks = "0"
 
     def update(self):
-        """Return a string with the number of pending tasks from TaskWarrior."""
+        """Return a string with the number of pending tasks from TaskWarrior
+        or the descripton of an active task.
+
+        if show.active is set in the config, show the description of the
+        current active task, otherwise the number of pending tasks will be displayed.
+        """
         try:
             taskrc = self.parameter("taskrc", "~/.taskrc")
             show_active = self.parameter("show_active", False)
@@ -33,6 +38,8 @@ class Module(core.module.Module):
                 w.filter_tasks({"start.any": "", "status": "pending"}) or None
             )
             if show_active and active_tasks:
+                # this is using the first element of the list, if there happen
+                # to be other active tasks, they won't be displayed.
                 reporting_tasks = (
                     f"{active_tasks[0]['id']} - {active_tasks[0]['description']}"
                 )

--- a/bumblebee_status/modules/contrib/taskwarrior.py
+++ b/bumblebee_status/modules/contrib/taskwarrior.py
@@ -27,12 +27,22 @@ class Module(core.module.Module):
         """Return a string with the number of pending tasks from TaskWarrior."""
         try:
             taskrc = self.parameter("taskrc", "~/.taskrc")
+            show_active = self.parameter("show_active", False)
             w = TaskWarrior(config_filename=taskrc)
-            pending_tasks = w.filter_tasks({"status": "pending"})
-            self.__pending_tasks = str(len(pending_tasks))
+            active_tasks = (
+                w.filter_tasks({"start.any": "", "status": "pending"}) or None
+            )
+            if show_active and active_tasks:
+                reporting_tasks = (
+                    f"{active_tasks[0]['id']} - {active_tasks[0]['description']}"
+                )
+            else:
+                reporting_tasks = len(w.filter_tasks({"status": "pending"}))
+            self.__pending_tasks = reporting_tasks
         except:
             self.__pending_tasks = "n/a"
 
+    @core.decorators.scrollable
     def output(self, _):
         """Format the task counter to output in bumblebee."""
         return "{}".format(self.__pending_tasks)

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1612,6 +1612,7 @@ Requires the following library:
 
 Parameters:
     * taskwarrior.taskrc : path to the taskrc file (defaults to ~/.taskrc)
+    * taskwarrior.show_active: true/false(default) to show the active task ID and description when one is active, otherwise show the total number pending.
 
 
 contributed by `chdorb <https://github.com/chdorb>`_ - many thanks!


### PR DESCRIPTION
Updated taskwarrior.py to accept a show.active param, which will change the behavior to show pending tasks ordinarily, but will display the current active task ID and description if the option is set, and there is an active task.