### PR TITLE
Correct battery modules handling of critical/warning states

### DIFF
--- a/bumblebee_status/modules/contrib/battery-upower.py
+++ b/bumblebee_status/modules/contrib/battery-upower.py
@@ -211,7 +211,9 @@ class UPowerManager:
         battery_proxy = self.bus.get_object(self.UPOWER_NAME, battery)
         battery_proxy_interface = dbus.Interface(battery_proxy, self.DBUS_PROPERTIES)
 
-        return bool(battery_proxy_interface.Get(self.UPOWER_NAME + ".Device", "IsPresent"))
+        return bool(
+            battery_proxy_interface.Get(self.UPOWER_NAME + ".Device", "IsPresent")
+        )
 
     def is_loading(self, battery):
         battery_proxy = self.bus.get_object(self.UPOWER_NAME, battery)
@@ -309,11 +311,6 @@ class Module(core.module.Module):
         if capacity < 0:
             return ["critical", "unknown"]
 
-        if capacity < int(self.parameter("critical", 10)):
-            state.append("critical")
-        elif capacity < int(self.parameter("warning", 20)):
-            state.append("warning")
-
         if widget.get("ac"):
             state.append("AC")
         else:
@@ -339,6 +336,16 @@ class Module(core.module.Module):
                     state.append("charged")
                 else:
                     state.append("charging")
+        if (
+            capacity < int(self.parameter("critical", 10))
+            and self.power.get_state(self.device) == "Discharging"
+        ):
+            state.append("critical")
+        elif (
+            capacity < int(self.parameter("warning", 20))
+            and self.power.get_state(self.device) == "Discharging"
+        ):
+            state.append("warning")
         return state
 
 

--- a/bumblebee_status/modules/contrib/battery.py
+++ b/bumblebee_status/modules/contrib/battery.py
@@ -180,11 +180,6 @@ class Module(core.module.Module):
             log.debug("battery state: {}".format(state))
             return ["critical", "unknown"]
 
-        if capacity < int(self.parameter("critical", 10)):
-            state.append("critical")
-        elif capacity < int(self.parameter("warning", 20)):
-            state.append("warning")
-
         if widget.get("ac"):
             state.append("AC")
         else:
@@ -209,6 +204,18 @@ class Module(core.module.Module):
                     state.append("charged")
                 else:
                     state.append("charging")
+
+        if (
+            capacity < int(self.parameter("critical", 10))
+            and self.__manager.charge_any(self._batteries) == "Discharging"
+        ):
+            state.append("critical")
+        elif (
+            capacity < int(self.parameter("warning", 20))
+            and self.__manager.charge_any(self._batteries) == "Discharging"
+        ):
+            state.append("warning")
+
         return state
 
 


### PR DESCRIPTION
The logic for the critical/warning handling on the battery modules was applied BEFORE the discharging-<pct> logic.  This made it  possible for those discharging states to get applied over a critical/warning and allow a theme to override the critical/warning colors with a state of "discharging-10", for example.

This change moves that logic after the discharging state, so that it will always "win" if critical or warning states are set.

This also adds the "discharging" battery state to the critical/warning check so the state will apply if the battery is not on AC power, but would return normal otherwise.  Meaning, if the battery is "critical" from a percentage check, but is plugged into power, the critical state is removed.