### PR TITLE
contrib/network_traffic dependency in docs

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1126,7 +1126,9 @@ network_traffic
 ~~~~~~~~~~~~~~~
 
 Displays network traffic
-   * No extra configuration needed
+
+Requires the following library:
+    * netifaces
 
 contributed by `izn <https://github.com/izn>`_ - many thanks!
 


### PR DESCRIPTION
network_traffic [is dependent on netifaces](https://github.com/tobi-wan-kenobi/bumblebee-status/blob/main/bumblebee_status/modules/contrib/network_traffic.py#L11) which is not a core python module. Reflecting it on the docs