### PR TITLE
Don't install manpages to /usr/usr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         ("share/bumblebee-status/themes", glob.glob("themes/*.json")),
         ("share/bumblebee-status/themes/icons", glob.glob("themes/icons/*.json")),
         ("share/bumblebee-status/utility", glob.glob("bin/*")),
-        ("usr/share/man/man1", glob.glob("man/*.1")),
+        ("share/man/man1", glob.glob("man/*.1")),
     ],
     packages=find_packages(exclude=["tests", "tests.*"])
 )


### PR DESCRIPTION
`data_files` shouldn't have `usr/` in it; this causes the manpages to be installed to `/usr/usr/share/man/man1` instead of `/usr/share/man/man1`.