### PR TITLE
publicip - Bug Fix

### DIFF
--- a/bumblebee_status/modules/contrib/publicip.py
+++ b/bumblebee_status/modules/contrib/publicip.py
@@ -72,8 +72,10 @@ class Module(core.module.Module):
             # Look for any changes to IP addresses
             try:
                 for interface in netifaces.interfaces():
-                    __current_ips.add(netifaces.ifaddresses(interface)[2][0]['addr'])
-                    
+                    try:
+                        __current_ips.add(netifaces.ifaddresses(interface)[2][0]['addr'])
+                    except:
+                        pass
             except:
             # If not ip address information found clear __current_ips
                 __current_ips.clear()


### PR DESCRIPTION
IP address changes were being missed if an interface was present but did not have an IPv4 address associated with it. Added exception handling to mitigate this.