### PR TITLE
`watsonctl.py` an interactive extension to `watson.py`

### DIFF
--- a/bumblebee_status/modules/contrib/watsonctl.py
+++ b/bumblebee_status/modules/contrib/watsonctl.py
@@ -1,0 +1,92 @@
+# pylint: disable=C0111,R0903
+
+"""Displays the status of watson (time-tracking tool)
+Requires the following executable:
+    * watson
+origional module contributed by `bendardenne <https://github.com/bendardenne>`_ - many thanks!
+extended by `dale-muccignat <https://github.com/dale-muccignat>`_
+"""
+
+import logging
+import re
+import functools
+
+import core.module
+import core.widget
+import core.input
+import core.decorators
+
+import util.cli
+
+
+class Module(core.module.Module):
+    # @core.decorators.every(minutes=1)
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.text))
+
+        self.__tracking = False
+        self.__status = ""
+        self.__project = "Select Project"
+
+        self.__project_key = {}
+        self.__project_list = []
+        self.get_list()
+
+        core.input.register(self, button=core.input.LEFT_MOUSE, cmd=self.toggle)
+        core.input.register(self, button=core.input.WHEEL_UP, cmd=self.change_project)
+        core.input.register(self, button=core.input.WHEEL_DOWN, cmd=self.change_project)
+
+    def get_list(self):
+        # updates the list of current projects and creats a key dictionary
+        self.__project_list = util.cli.execute("watson projects").split()
+        for n in range(len(self.__project_list)):
+            self.__project_key[self.__project_list[n]] = n
+
+    def toggle(self, widget):
+        # on click, starts the timer if the project is slected
+        if self.__project != "Select Project":
+            if self.__tracking:
+                util.cli.execute("watson stop")
+                self.__status = "Paused"
+            else:
+                util.cli.execute("watson start " + self.__project)
+                self.__status = "Play"
+            self.__tracking = not self.__tracking
+
+    def change_project(self, event):
+        # on scroll, cycles the currently selected project
+        if self.__tracking:
+            return
+        if self.__project == "Select Project":
+            self.__project = self.__project_list[0]
+        else:
+            n = self.__project_key[self.__project]
+            if n < len(self.__project_list) - 1:
+                self.__project = self.__project_list[n + 1]
+            else:
+                self.__project = self.__project_list[0]
+
+    def text(self, widget):
+        if self.__tracking:
+            return self.__project + ": " + self.__status
+        else:
+            return self.__project + ": " + self.__status
+
+    def update(self):
+        output = util.cli.execute("watson status")
+        if re.match(r"No project started", output):
+            self.__tracking = False
+            self.__status = "Paused"
+            return
+
+        self.__tracking = True
+        m = re.search(r"Project (.+) started", output)
+        self.__project = m.group(1)
+        self.__status = "Play"
+        self.get_list()
+
+    def state(self, widget):
+        return "on" if self.__tracking else "off"
+
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
I'm hoping this will serve as an alternative to watson.py. I started using watson.py and felt like it'd be great to have some control over what project is being tracked rather than 'just' restarting the last tracked project.

So I went about changing the code from watson.py to include a feature that when the mouse wheel is used, the module cycles between currently used projects within watson. I have limited python experience as I mainly use Julialang for research so I'm reaching the end of the effort I can put into this for now. I'd love for some pointers and I can come back to improve this.

I'm not really looking to merge this right away, I think it's usable as is but I would love for it to be improved. 

Main features:
- Mouse scroll to select from existing projects

Current drawbacks:
- No way of starting a new tracked project. I can't wrap my head around a way to easily start a new project with a custom name from the module
- No fancy icons, I need to read more of the docs for bumblebee to add in some fancy icons to indicate if the project is being tracked or not currently

Wishlist:
- right-click to display the aggrigate total times for each project
- change colour of the module when time is being tracked