### PR TITLE
add pipewire module

### DIFF
--- a/bumblebee_status/modules/contrib/pipewire.py
+++ b/bumblebee_status/modules/contrib/pipewire.py
@@ -1,0 +1,90 @@
+"""get volume level or control it
+
+Requires the following executable:
+    * wpctl
+
+Parameters:
+    * wpctl.percent_change: How much to change volume by when scrolling on the module (default is 4%)
+
+heavily based on amixer module
+"""
+import re
+
+import core.module
+import core.widget
+import core.input
+
+import util.cli
+import util.format
+
+
+class Module(core.module.Module):
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.volume))
+
+        self.__level = "N/A"
+        self.__muted = True
+        self.__change = (
+            util.format.asint(self.parameter("percent_change", "4%").strip("%"), 0, 200)
+            / 100.0
+        )  # divide by 100 because wpctl represents 100% volume as 1.00, 50% as 0.50, etc
+
+        events = [
+            {
+                "type": "mute",
+                "action": self.toggle,
+                "button": core.input.LEFT_MOUSE,
+            },
+            {
+                "type": "volume",
+                "action": self.increase_volume,
+                "button": core.input.WHEEL_UP,
+            },
+            {
+                "type": "volume",
+                "action": self.decrease_volume,
+                "button": core.input.WHEEL_DOWN,
+            },
+        ]
+
+        for event in events:
+            core.input.register(self, button=event["button"], cmd=event["action"])
+
+    def toggle(self, event):
+        util.cli.execute("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle")
+
+    def increase_volume(self, event):
+        util.cli.execute(
+            "wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ {}+".format(
+                self.__change
+            )
+        )
+
+    def decrease_volume(self, event):
+        util.cli.execute(
+            "wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ {}-".format(
+                self.__change
+            )
+        )
+
+    def volume(self, widget):
+        return "{}%".format(int(float(self.__level) * 100))
+
+    def update(self):
+        try:
+            # `wpctl get-volume` will return a string like "Volume: n.nn" or "Volume: n.nn [MUTED]"
+            volume = util.cli.execute("wpctl get-volume @DEFAULT_AUDIO_SINK@")
+            v = re.search("\d\.\d+", volume)
+            m = re.search("MUTED", volume)
+            self.__level = v.group()
+            self.__muted = True if m else False
+        except Exception:
+            self.__level = "N/A"
+
+    def state(self, widget):
+        if self.__muted:
+            return ["warning", "muted"]
+        return ["unmuted"]
+
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -229,6 +229,14 @@
       "prefix": ""
     }
   },
+  "pipewire": {
+    "muted": {
+      "prefix": ""
+    },
+    "unmuted": {
+      "prefix": ""
+    }
+  },
   "kernel": {
     "prefix": "\uf17c"
   },


### PR DESCRIPTION
---
name: add module for pipewire
about: uses wpctl to get and update volume in pipewire
---

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
add a module for pipewire. basically identical to existing amixer and pamixer modules, but using wpctl

**Summary**
for folks using pipewire, they probably have a pipewire pulse bridge of some kind installed that some applications depend on, and pamixer/pactl/other pulse things may work intermittently depending on which application is currently playing audio. wpctl should work all the time though

**Does this PR introduce a breaking change?**
no

**Other information**
I tested this and it Works On My Machine (tm)
