### PR TITLE
fix bug in pipewire module

### DIFF
--- a/bumblebee_status/modules/contrib/pipewire.py
+++ b/bumblebee_status/modules/contrib/pipewire.py
@@ -68,6 +68,8 @@ class Module(core.module.Module):
         )
 
     def volume(self, widget):
+        if self.__level == "N/A":
+            return self.__level
         return "{}%".format(int(float(self.__level) * 100))
 
     def update(self):


### PR DESCRIPTION
- fix bug in pipewire module

---
name: Improvement
about: You have some improvement to make bumblebee-status bar better?
---

### Improvement
<!-- Fill in the relevant information below to help triage your issue. -->

there was a bug in my initial implementation - if the string "N/A" is returned because for some reason the volume can't be fetched for a tick during an update (seems to happen sometimes when switching audio streams), the code tries to convert it to a float, which throws a ValueError and crashes bumblebee. make sure to catch that case
