### PR TITLE
remove unnecessary `playerctl` subprocess call to determine whether widget should be hidden

### DIFF
--- a/bumblebee_status/modules/contrib/playerctl.py
+++ b/bumblebee_status/modules/contrib/playerctl.py
@@ -34,6 +34,7 @@ class Module(core.module.Module):
         self.background = True
 
         self.__hide = util.format.asbool(self.parameter("hide", "false"));
+        self.__hidden = self.__hide
 
         self.__layout = util.format.aslist(
             self.parameter(
@@ -87,7 +88,7 @@ class Module(core.module.Module):
                 core.input.register(widget, **callback_options)
 
     def hidden(self):
-        return self.__hide and self.status() == None
+        return self.__hidden
 
     def status(self):
         try:
@@ -101,6 +102,10 @@ class Module(core.module.Module):
 
     def update(self):
         playback_status = self.status()
+        if not playback_status:
+            self.__hidden = self.__hide
+        else:
+            self.__hidden = False
         for widget in self.widgets():
             if playback_status:
                 if widget.name == "playerctl.pause":


### PR DESCRIPTION
Hi,

On my system (Linux Mint 21, i3-gaps 4.21), using the `playerctl.hide` config option would lead to random failures:
- widget sometimes not properly updating
- long running (multiple seconds) calls to `playerctl` showing up in `top` marked as put to sleep
-  exceptions in `.xsession-errors` like such:
```
[2023-03-15 15:01:55,837] playerctl        ERROR    playerctl  metadata -f '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}' exited with code 1
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/bumblebee_status/modules/contrib/playerctl.py", line 127, in __get_song
    return str(util.cli.execute(self.__cmd + "metadata -f '" + self.__format + "'")).strip()
  File "/home/user/.local/lib/python3.10/site-packages/bumblebee_status/util/cli.py", line 61, in execute
    raise RuntimeError(err)
RuntimeError: playerctl  metadata -f '{{artist}} - {{title}}  {{duration(position)}}/{{duration(mpris:length)}}' exited with code 1
```

Removing an additional unnecessary subprocess call to `playerctl` from the `hidden()` method fixes this completely. It is anyway sufficient to check whether the widget should be hidden at update time.