### PR TITLE
Added path for themes directory when installed via pipx

### DIFF
--- a/bumblebee_status/core/theme.py
+++ b/bumblebee_status/core/theme.py
@@ -25,6 +25,7 @@ if os.environ.get("XDG_DATA_DIRS"):
 PATHS.extend([
     os.path.expanduser("~/.config/bumblebee-status/themes"),
     os.path.expanduser("~/.local/share/bumblebee-status/themes"),  # PIP
+    os.path.expanduser("~/.local/pipx/venvs/bumblebee-status/share/bumblebee-status/themes"),  # PIPX
     "/usr/share/bumblebee-status/themes",
 ])
 


### PR DESCRIPTION
bumblebee-status fails with:

```
Traceback (most recent call last):
  File "/home/username/.local/bin/bumblebee-status", line 17, in <module>
    import core.output
  File "/home/username/.local/pipx/venvs/bumblebee-status/lib/python3.10/site-packages/bumblebee_status/core/output.py", line 143, in <module>
    class i3(object):
  File "/home/username/.local/pipx/venvs/bumblebee-status/lib/python3.10/site-packages/bumblebee_status/core/output.py", line 144, in i3
    def __init__(self, theme=core.theme.Theme(), config=core.config.Config([])):
  File "/home/username/.local/pipx/venvs/bumblebee-status/lib/python3.10/site-packages/bumblebee_status/core/theme.py", line 63, in __init__
    self.__data = raw_data if raw_data else self.load(name)
  File "/home/username/.local/pipx/venvs/bumblebee-status/lib/python3.10/site-packages/bumblebee_status/core/theme.py", line 89, in load
    raise RuntimeError("unable to find theme {}".format(name))
RuntimeError: unable to find theme default
```

when invoked after being installed via `pipx` because the theme paths are different. This PR just adds an extra line to specify the correct path to themes when installed via `pipx`