### PR TITLE
Change OpenWeatherMap request url from HTTP to HTTPS

### DIFF
--- a/bumblebee_status/modules/contrib/weather.py
+++ b/bumblebee_status/modules/contrib/weather.py
@@ -13,7 +13,7 @@ Parameters:
     * weather.unit: metric (default), kelvin, imperial
     * weather.showcity: If set to true, show location information, otherwise hide it (defaults to true)
     * weather.showminmax: If set to true, show the minimum and maximum temperature, otherwise hide it (defaults to false)
-    * weather.apikey: API key from http://api.openweathermap.org
+    * weather.apikey: API key from https://api.openweathermap.org
 
 
 contributed by `TheEdgeOfRage <https://github.com/TheEdgeOfRage>`_ - many thanks!
@@ -116,7 +116,7 @@ class Module(core.module.Module):
 
     def update(self):
         try:
-            weather_url = "http://api.openweathermap.org/data/2.5/weather?appid={}".format(
+            weather_url = "https://api.openweathermap.org/data/2.5/weather?appid={}".format(
                 self.__apikey
             )
             weather_url = "{}&units={}".format(weather_url, self.__unit)


### PR DESCRIPTION
I was noticing that the weather module had stopped working and was hanging waiting for a response from http://api.openweathermap.org.

Changing this request to "https://" fixed the issue and the weather module works again.