### PR TITLE
Add: missing mention of pipewire module on website

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1243,6 +1243,19 @@ Parameters:
 
 contributed by `bbernhard <https://github.com/bbernhard>`_ - many thanks!
 
+pipewire
+~~~~~~~
+
+get volume level or control it
+
+Requires the following executable:
+    * wpctl
+
+Parameters:
+    * wpctl.percent_change: How much to change volume by when scrolling on the module (default is 4%)
+
+heavily based on amixer module
+
 playerctl
 ~~~~~~~~~
 


### PR DESCRIPTION
I was reading the docs on the website(https://bumblebee-status.readthedocs.io/en/latest/modules.html#contrib) and there was no mention of the pipewire module which exists among the contrib modules. This edit will inform users about the pipewire module