### PR TITLE
Fix: pipewire.py module

### DIFF
--- a/bumblebee_status/modules/contrib/pipewire.py
+++ b/bumblebee_status/modules/contrib/pipewire.py
@@ -57,12 +57,12 @@ class Module(core.module.Module):
 
     def increase_volume(self, event):
         util.cli.execute(
-            "wpctl set-volume --limit 1.0 {} {}+".format(self.__change, self.__id)
+            "wpctl set-volume --limit 1.0 {} {}+".format(self.__id, self.__change)
         )
 
     def decrease_volume(self, event):
         util.cli.execute(
-            "wpctl set-volume --limit 1.0 {} {}-".format(self.__change, self.__id)
+            "wpctl set-volume --limit 1.0 {} {}-".format(self.__id, self.__change)
         )
 
     def volume(self, widget):


### PR DESCRIPTION
mousewheel up and down events were initially not working on my bumblebee status bar. After verifying on the command line, it seems that wpctl set-volume command requires sink ID first and percentage change as the second arg.

steps to verify, assuming wireplumber is installed and sink ID is 32

```sh
wpctl set-volume 32 50%
```
will set the volume to 50%

```sh
wpctl set-volume 50% 32
```
will result in `Object '52' not found`

After switching `self.__change` and `self.__id`, mousewheel up and down events worked as expected increasing and decreasing volume. 

I also wanted to take the opportunity to ask you if we can write python modules using f-strings instead of the str.format() for better readability? I believe this will break compatibility with Python versions <3.6 as f-strings were introduced in Python v3.6.