### PR TITLE
poll window title also on workspace change (not only window events)

### DIFF
--- a/bumblebee_status/modules/contrib/title.py
+++ b/bumblebee_status/modules/contrib/title.py
@@ -50,8 +50,9 @@ class Module(core.module.Module):
 
         # create a connection with i3ipc
         self.__i3 = i3ipc.Connection()
-        # event is called both on focus change and title change
+        # event is called both on focus change and title change, and on workspace change
         self.__i3.on("window", lambda __p_i3, __p_e: self.__pollTitle())
+        self.__i3.on("workspace", lambda __p_i3, __p_e: self.__pollTitle())
         # begin listening for events
         threading.Thread(target=self.__i3.main).start()
 


### PR DESCRIPTION
Currently, the `title` module only considers window events. That means that the previous window title remains displayed even if the workspace is switched to an empty workspace. 

This changes that behaviour so that also workspace events are listened to. Now switching to an empty workspace removes the window title and replaces it with the name of the workspace.