### PR TITLE
Module for displaying date with gnome-calendar opening on click

### DIFF
--- a/bumblebee_status/modules/contrib/calendar.py
+++ b/bumblebee_status/modules/contrib/calendar.py
@@ -1,0 +1,24 @@
+"""Displays date, opens a gnome-calendar on click
+
+Parameters:
+    * calendar.format: strftime()-compatible formatting string
+    * calendar.locale: locale to use rather than the system default
+"""
+
+import core.decorators
+from ..core.datetime import Module
+
+import core.input
+
+
+class Module(Module):
+    @core.decorators.every(hours=1)
+    def __init__(self, config, theme):
+        super().__init__(config, theme)
+        core.input.register(self, button=core.input.LEFT_MOUSE, cmd="gnome-calendar")
+
+    def default_format(self):
+        return "%x"
+
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -11,6 +11,9 @@
   "date": {
     "prefix": ""
   },
+  "calendar": {
+    "prefix": ""
+  },
   "persian_date": {
     "prefix": ""
   },


### PR DESCRIPTION
Hi, 
I love the project been using it for a while. I love how easy it is to use and even implement custom modules. Thankfully to that I have been able to seamlessly modify it for my use case. I felt a personal requirement for this module as I need to open up calendar for setting up reminders a lot and opening it up from the bar seemed the easiest and most natural, probably **this should exist in the core date module** but didn't wanna touch it.
Let me know if I should make any changes to this or anything at all, I am new to all this... I appreciate the feedback/critic. :)   