### PR TITLE
[modules/disk] Use bavail instead of bfree

### DIFF
--- a/bumblebee_status/modules/core/disk.py
+++ b/bumblebee_status/modules/core/disk.py
@@ -56,8 +56,8 @@ class Module(core.module.Module):
     def update(self):
         st = os.statvfs(self._path)
         self._size = st.f_blocks * st.f_frsize
-        self._used = (st.f_blocks - st.f_bfree) * st.f_frsize
-        self._left = self._size - self._used
+        self._left = st.f_bavail * st.f_frsize
+        self._used = self._size - self._left
         self._percent = 100.0 * self._used / self._size
 
     def state(self, widget):


### PR DESCRIPTION
The ext4 filesystem reserves 5 % of disk size. `os.statvfs(path).f_bfree` reports this reserve as free disk space, while `f_bavail` considers it "full".

I believe `f_bavail` gives more useful information, as the reserved space cannot be used. Also, it's in line with what `df` reports.