### PR TITLE
redshift: added -P argument to prevent cumulative effects

### DIFF
--- a/bumblebee_status/modules/core/redshift.py
+++ b/bumblebee_status/modules/core/redshift.py
@@ -42,7 +42,7 @@ def get_redshift_value(module):
     command = ["redshift"]
 
     if util.format.asbool(module.parameter("adjust", "false")) == True:
-        command.extend(["-o", "-v"])
+        command.extend(["-o", "-v", "-P"])
     else:
         command.append("-p")
 


### PR DESCRIPTION
In adjust=true mode, redshift starts to stack applied effect and screen starts dim more and more every interval. Adding -P argument solves this issue.