### PR TITLE
fix(modules,core,nix): respect include and exclude correctly when using multiple aliases

### DIFF
--- a/bumblebee_status/core/module.py
+++ b/bumblebee_status/core/module.py
@@ -211,7 +211,7 @@ class Module(core.input.Object):
     """
 
     def add_widget(self, full_text="", name=None, hidden=False):
-        widget_id = "{}::{}".format(self.name, len(self.widgets()))
+        widget_id = "{}::{}".format(self.id, len(self.widgets()))
         widget = core.widget.Widget(full_text=full_text, name=name, widget_id=widget_id, hidden=hidden)
         self.widgets().append(widget)
         widget.module = self


### PR DESCRIPTION
I was experiencing weird behaviour of the nic module, when I was using it with aliases.
I will try to explain what I mean.

Minimal reproducible:
```
[core]
modules = nic:wg,nic:eth,nic:wifi

[module-parameters]
wg.format = {intf}
wg.include = wg-01

eth.exclude = lo,virbr,docker,vboxnet,veth,br,.*:avahi,wg-01,wlan0
eth.format = {state}

wifi.include = wlan0
wifi.format = {ssid}
```

* This config should show the widget for `wg`, if it is there, where it shows the interfaces name.
* For everything that is not any interface excluded by default and not `wg-01` or `wlan0`, it should just show the state.
* If present, the SSID for `wlan0` should be shown

This caused my bar to switch back and forth, some settings were overwriting others and `include` was not working at all. Maybe if I would have overwritten the `exclude` to be all and then used `include` it would have worked. But for me this is unintuitive behaviour.

If you have questions about why I changed it the way I did, please ask me.

My i3-bar can now look like this:
![grafik](https://github.com/tobi-wan-kenobi/bumblebee-status/assets/18399895/5c5735a0-b19a-4771-997b-007ab8402a75)
