### PR TITLE
fix(modules,contrib,thunderbird): correctly use hex and A1 key

### DIFF
--- a/bumblebee_status/modules/contrib/thunderbird.py
+++ b/bumblebee_status/modules/contrib/thunderbird.py
@@ -63,7 +63,7 @@ class Module(core.module.Module):
         cmd = (
             "find "
             + self.__home
-            + " -name '*.msf' -exec grep -REo 'A2=[0-9]' {} + | grep"
+            + " -name '*.msf' -exec grep -REo '\^A1=[0-9a-fA-F]+)' {} + | grep"
         )
         for inbox in self.__inboxes:
             cmd += " -e {}".format(inbox)
@@ -74,9 +74,9 @@ class Module(core.module.Module):
     def __getUnreadMessagesByInbox(self, stream):
         unread = {}
         for line in stream:
-            entry = line.split(":A2=")
+            entry = line.split(":^A1=")
             inbox = entry[0]
-            count = entry[1]
+            count = str(int(entry[1][:-1], 16))
             unread[inbox] = count
 
         return unread


### PR DESCRIPTION
I found out that the format for the unread message is actually HEX. And the key is `A1`, according to this header of an inbox file of mine.
```
< <(a=c)> // (f=iso-8859-1)
  (B8=highestRecordedUID)(B9=ns:msg:db:row:scope:pending:all)
  (BA=ns:msg:db:table:kind:pending)(BB=dateReceived)(BC=ProtoThreadFlags)
  (BD=sender_name)(BE=keywords)(BF=imageSize)(C0=junkscore)
  (C1=folderName)(C2=replyTo)(C3=junkscoreorigin)
  (C4=dobayes.mailnews@mozilla.org#junk.empty)
  (C5=dobayes.mailnews@mozilla.org#junk)(C6=preview)(C7=storeToken)
  (C8=gloda-id)(C9=gloda-dirty)(CA=notAPhishMessage)
  (CB=ns:msg:db:row:scope:ops:all)(CC=ns:msg:db:table:kind:ops)
  (80=ns:msg:db:row:scope:msgs:all)(81=subject)(82=sender)(83=message-id)
  (84=references)(85=recipients)(86=date)(87=size)(88=flags)(89=priority)
  (8A=label)(8B=numLines)(8C=ccList)(8D=bccList)(8E=msgThreadId)
  (8F=threadId)(90=threadFlags)(91=threadNewestMsgDate)(92=children)
  (93=unreadChildren)(94=threadSubject)(95=msgCharSet)
  (96=ns:msg:db:table:kind:msgs)(97=ns:msg:db:table:kind:thread)
  (98=ns:msg:db:table:kind:allthreads)
  (99=ns:msg:db:row:scope:threads:all)(9A=threadParent)(9B=threadRoot)
  (9C=msgOffset)(9D=offlineMsgSize)
  (9E=ns:msg:db:row:scope:dbfolderinfo:all)
  (9F=ns:msg:db:table:kind:dbfolderinfo)(A0=numMsgs)(A1=numNewMsgs)
  (A2=folderSize)(A3=expungedBytes)(A4=folderDate)(A5=highWaterKey)
  (A6=mailboxName)(A7=UIDValidity)(A8=totPendingMsgs)
  (A9=unreadPendingMsgs)(AA=expiredMark)(AB=version)(AC=forceReparse)
  (AD=fixedBadRefThreading)(AE=onlineName)(AF=useServerRetention)
  (B0=MRUTime)(B1=sortType)(B2=sortOrder)(B3=viewFlags)(B4=viewType)
  (B5=sortColumns)(B6=highestModSeq)(B7=imapFlags)>
```
It shows the correct number now for me.