### PR TITLE
fix(modules,contrib,thunderbird): grep binary file error

### DIFF
--- a/bumblebee_status/modules/contrib/thunderbird.py
+++ b/bumblebee_status/modules/contrib/thunderbird.py
@@ -63,7 +63,7 @@ class Module(core.module.Module):
         cmd = (
             "find "
             + self.__home
-            + " -name '*.msf' -exec grep -REo '\^A1=[0-9a-fA-F]+)' {} + | grep"
+            + " -name '*.msf' -exec grep -aREo '\^A1=[0-9a-fA-F]+)' {} + | grep"
         )
         for inbox in self.__inboxes:
             cmd += " -e {}".format(inbox)


### PR DESCRIPTION
I saw that grep sometimes thinks the `.msf` file is a binary, so I added `-a` as a flag which tells grep to look inside binary files as well.
From `man grep`:
```
   File and Directory Selection
       -a, --text
              Process a binary file as if it were text; this is equivalent to the --binary-files=text option.
```