### PR TITLE
Add oled_offset module

### DIFF
--- a/bumblebee_status/modules/contrib/oled_offset.py
+++ b/bumblebee_status/modules/contrib/oled_offset.py
@@ -1,0 +1,27 @@
+# pylint: disable=C0111,R0903
+
+"""Creates an empty widget that changes width on a timer,
+to reduce changes o OLED burn-in from other bumblebee modules.
+
+You should put this module as the last one,
+so all the other modules are moved when this one changes in width
+
+contributed by `TheEdgeOfRage <https://github.com/TheEdgeOfRage>`_ - many thanks!
+"""
+
+import core.module
+import core.widget
+import core.decorators
+
+
+class Module(core.module.Module):
+    @core.decorators.every(minutes=1)
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.content))
+        self.__offset = 0
+
+    def content(self, _):
+        return self.__offset * " "
+
+    def update(self):
+        self.__offset = (self.__offset + 1) % 3

--- a/tests/modules/contrib/test_oled_offset.py
+++ b/tests/modules/contrib/test_oled_offset.py
@@ -1,0 +1,5 @@
+import pytest
+
+def test_load_module():
+    __import__("modules.contrib.oled_offset")
+

--- a/themes/icons/awesome-fonts.json
+++ b/themes/icons/awesome-fonts.json
@@ -742,5 +742,8 @@
   },
   "power-profile": {
     "prefix": "\uF2C1"
+  },
+  "oled_offset": {
+    "padding": ""
   }
 }


### PR DESCRIPTION
I recently got an OLED monitor and as a precaution, decided to add this module that occasionally (every minute) moves the entire bumblebee-status status bar to the left, so that it's not always the same pixels that are lit up, to mitigate burn-in. It resets back to 0 after 3 steps.