### PR TITLE
Fix the parameter name for the `pipewire` module

### DIFF
--- a/bumblebee_status/modules/contrib/pipewire.py
+++ b/bumblebee_status/modules/contrib/pipewire.py
@@ -4,7 +4,7 @@ Requires the following executable:
     * wpctl
 
 Parameters:
-    * wpctl.percent_change: How much to change volume by when scrolling on the module (default is 4%)
+    * pipewire.percent_change: How much to change volume by when scrolling on the module (default is 4%)
 
 heavily based on amixer module
 """

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1334,7 +1334,7 @@ Requires the following executable:
     * wpctl
 
 Parameters:
-    * wpctl.percent_change: How much to change volume by when scrolling on the module (default is 4%)
+    * pipewire.percent_change: How much to change volume by when scrolling on the module (default is 4%)
 
 heavily based on amixer module
 


### PR DESCRIPTION
The current `wpctl.percent_change` is not valid, while `pipewire.percent_change` does work!