### PR TITLE
fix: test pipeline | install missing dependency for dbus

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Update Ubuntu
         run: sudo apt-get update
       - name: Install Ubuntu dependencies
-        run: sudo apt-get install -y libdbus-1-dev libgit2-dev libvirt-dev taskwarrior
+        run: sudo apt-get install -y libdbus-1-dev libgit2-dev libvirt-dev taskwarrior libglib2.0-dev
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
[Failing Tests](https://github.com/tobi-wan-kenobi/bumblebee-status/actions/runs/13711481142/job/38348683883)     

` ../subprojects/dbus-gmain/meson.build:108:11: ERROR: Dependency "glib-2.0" not found, tried pkgconfig and cmake`

The test pipeline is failing because of a missing dependency for dbus in the latest ubuntu image. installing this dependency fixes the pipeline:

[Passing Tests](https://github.com/theymightbetim/bumblebee-status/actions/runs/13712729380)