### PR TITLE
fix: blank line at end of requirements file to fix module imports

### DIFF
--- a/requirements/modules/otp.txt
+++ b/requirements/modules/otp.txt
@@ -1,3 +1,2 @@
 keyring
 pyotp
-requests


### PR DESCRIPTION
I broke the test pipeline again with the OTP module because the requirements file was missing a blank line at the end causing it to concatenate the last module in otp.txt with the first module in pihole.txt and then become unable to find a package called pyotprequests instead of installing pyopt and requests.

Sorry about this, I was unable to run the tests before because the pipeline was broken.

[Tests Passing Again](https://github.com/theymightbetim/bumblebee-status/actions/runs/13722033184)