### PR TITLE
fix: dnf module doesn't work for latest version of fedora/dnf5

### DIFF
--- a/bumblebee_status/modules/contrib/dnf.py
+++ b/bumblebee_status/modules/contrib/dnf.py
@@ -30,14 +30,14 @@ class Module(core.module.Module):
 
     def update(self):
         widget = self.widget()
-        res = util.cli.execute("dnf updateinfo", ignore_errors=True)
+        res = util.cli.execute("dnf updateinfo summary", ignore_errors=True)
 
         security = 0
         bugfixes = 0
         enhancements = 0
         other = 0
         for line in res.split("\n"):
-            if not line.startswith(" "):
+            if line.startswith(" "):
                 continue
             elif "ecurity" in line:
                 for s in line.split():


### PR DESCRIPTION
The current implementation of the dnf module doesn't work for Fedora 41. 
`dnf updateinfo` outputs a missing argument error causing it to always display 0/0/0/0

-Updated command to dnf updateinfo summary

the output of dnf updateinfo summary differs slightly from the former format. The new format is as follows:
```.venv➜  bumblebee-status git:(fix-dnf) ✗ dnf updateinfo summary         
Updating and loading repositories:
Repositories loaded.
Available advisory information summary:
Security    : 28
  Critical  : 1
  Important : 7
  Moderate  : 15
  Low       : 3
  Other     : 2
Bugfix      : 90
Enhancement : 63
Other       : 46
````


- Updated the parsing function to handle the new format.