### PR TITLE
Updated git module to support drawing widgets right to left

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -83,6 +83,9 @@ Requires:
     * xcwd
     * Python module 'pygit2'
 
+Parameters:
+    * git.draw_order: String to specify draw order of the widgets; Options are "ltr" for left to right, and "rtl" for right to left (defaults to "ltr")
+
 .. image:: ../screenshots/git.png
 
 keys


### PR DESCRIPTION
I am a first time user of bumblebee-status and was configuring it when I noticed there was support for rtl layout of modules, but not for individual widgets within many of the modules. 

Primarily, I would like to be able to use the git module in this way, so here is my PR.

# What this does
* Add support for rtl layout of widgets within git module
* Maintain support for ltr layout of widgets within git module
* Allows users to configure layout direction within the git module with parameter `git.draw_order`

# What this doesn't do
* Add support for rtl layouts in other modules
* Change behavior of any usage currently supported
* Change the order of the widgets with git module (still git.new -> git.modified -> git.deleted in either direction)

# Example usage
`bumblebee-status -t dracula-powerline -r -m date time battery pipewire xrandr nic git -p nic.format="{ssid}" nic.states="up" date.format="%a, %b %-d %Y" time.format="%-I:%M %p" git.draw_order="rtl"`
![2025-05-19-174247_872x44_scrot](https://github.com/user-attachments/assets/7538b046-9462-45db-b782-e5a0d6ca3683)
