### PR TITLE
Add waydroid network interface exclusion

### DIFF
--- a/bumblebee_status/modules/core/nic.py
+++ b/bumblebee_status/modules/core/nic.py
@@ -91,7 +91,7 @@ class Module(core.module.Module):
 
     def _iswlan(self, intf):
         # wifi, wlan, wlp, seems to work for me
-        if intf.startswith("w") and not intf.startswith("wg"):
+        if intf.startswith("w") and not intf.startswith("wg") and not intf.startswith("waydroid"):
             return True
         return False
 


### PR DESCRIPTION
Current wireless interface detection erroneously thinks interfaces like `waydroid0` are wireless interfaces.   This is a problem as it cases the whole status bar to crash out when the nic code tries to do a `iw` call on these interfaces later.  For now I added it to the exclusion list, which solves my problem.  Waydroid, if you are unaware is a tool for running android on top of linux.  I doubt it will come up much with bumblebee-status as it requires wayland, though I also run bumblee-status in Sway because I like it.  

Ultimately, a better fix, would be a much more robust way of detecting wireless interfaces, maybe by leveraging `iw`.  I might take another crack at this, but for now this fixes the specific issue.