### PR TITLE
location: Update geolocation service to ipwho.is

### DIFF
--- a/bumblebee_status/util/location.py
+++ b/bumblebee_status/util/location.py
@@ -19,7 +19,7 @@ __data = {}
 __next = 0
 __sources = [
     {
-        "url": "http://free.ipwhois.io/json/",
+        "url": "http://ipwho.is/",
         "mapping": {
             "latitude": "latitude",
             "longitude": "longitude",


### PR DESCRIPTION
free.ipwhois.io is now defunct.