### PR TITLE
Add multiple paths support to the disk module + showpath" config option + mouse wheel scroll

### DIFF
--- a/bumblebee_status/modules/core/disk.py
+++ b/bumblebee_status/modules/core/disk.py
@@ -5,7 +5,8 @@
 Parameters:
     * disk.warning: Warning threshold in % of disk space (defaults to 80%)
     * disk.critical: Critical threshold in % of disk space (defaults to 90%)
-    * disk.path: Path to calculate disk usage from (defaults to /)
+    * disk.path: Comma separated list of paths (defaults to /)
+    * disk.showpath: Enable or disable absolute path display (defaults to true)
     * disk.open: Which application / file manager to launch (default xdg-open)
     * disk.format: Format string, tags {path}, {used}, {left}, {size} and {percent} (defaults to '{path} {used}/{size} ({percent:05.02f}%)')
     * disk.system: Unit system to use - SI (KB, MB, ...) or IEC (KiB, MiB, ...) (defaults to 'IEC')
@@ -24,8 +25,17 @@ class Module(core.module.Module):
     def __init__(self, config, theme):
         super().__init__(config, theme, core.widget.Widget(self.diskspace))
 
-        self._path = self.parameter("path", "/")
-        self._format = self.parameter("format", "{used}/{size} ({percent:05.02f}%)")
+        self._indexPath = 0
+        self._path = tuple(
+                filter( len, util.format.aslist(self.parameter("path", "/")) )
+        )
+
+        self._showPath = util.format.asbool(self.parameter('showpath', True))
+        if self._showPath:
+            self._format = self.parameter("format", "({path}) {used}/{size} ({percent:05.02f}%)")
+        else:
+            self._format = self.parameter("format", "{used}/{size} ({percent:05.02f}%)")
+
         self._system = self.parameter("system", "IEC")
 
         self._used = 0
@@ -36,7 +46,19 @@ class Module(core.module.Module):
         core.input.register(
             self,
             button=core.input.LEFT_MOUSE,
-            cmd="{} {}".format(self.parameter("open", "xdg-open"), self._path),
+            cmd="{} {}".format(self.parameter("open", "xdg-open"), self._path[self._indexPath]),
+        )
+
+        core.input.register(
+            self,
+            button=core.input.WHEEL_UP,
+            cmd="nextPath",
+        )
+
+        core.input.register(
+            self,
+            button=core.input.WHEEL_DOWN,
+            cmd="prevPath",
         )
 
     def diskspace(self, widget):
@@ -46,7 +68,7 @@ class Module(core.module.Module):
         percent_str = self._percent
 
         return self._format.format(
-            path=self._path,
+            path=self._path[self._indexPath],
             used=used_str,
             left=left_str,
             size=size_str,
@@ -54,7 +76,7 @@ class Module(core.module.Module):
         )
 
     def update(self):
-        st = os.statvfs(self._path)
+        st = os.statvfs(self._path[self._indexPath])
         self._size = st.f_blocks * st.f_frsize
         self._left = st.f_bavail * st.f_frsize
         self._used = self._size - self._left
@@ -63,5 +85,16 @@ class Module(core.module.Module):
     def state(self, widget):
         return self.threshold_state(self._percent, 80, 90)
 
+    def nextPath(self, event):
+        self._indexPath += 1
+
+        if self._indexPath >= len(self._path):
+            self._indexPath = 0
+
+    def prevPath(self, event):
+        self._indexPath -= 1
+
+        if self._indexPath < 0:
+            self._indexPath = len(self._path) - 1
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -61,7 +61,8 @@ Shows free diskspace, total diskspace and the percentage of free disk space.
 Parameters:
     * disk.warning: Warning threshold in % of disk space (defaults to 80%)
     * disk.critical: Critical threshold in % of disk space (defaults to 90%)
-    * disk.path: Path to calculate disk usage from (defaults to /)
+    * disk.path: Comma separated list of paths (defaults to /)
+    * disk.showpath: Enable or disable absolute path display (defaults to true)
     * disk.open: Which application / file manager to launch (default xdg-open)
     * disk.format: Format string, tags {path}, {used}, {left}, {size} and {percent} (defaults to '{path} {used}/{size} ({percent:05.02f}%)')
     * disk.system: Unit system to use - SI (KB, MB, ...) or IEC (KiB, MiB, ...) (defaults to 'IEC')


### PR DESCRIPTION
This change allows users to:
-Specify multiple mount points or paths via the path option
-Toggle absolute (full) path display using the new boolean showpath option in the i3wm config
-Scroll between the selected paths using the mouse wheel

